### PR TITLE
Update to elasticsearch 1.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,8 @@
     </parent>
 
     <properties>
-        <elasticsearch.version>0.90.10</elasticsearch.version>
-        <lucene.version>4.6.0</lucene.version>
+        <elasticsearch.version>1.1.0</elasticsearch.version>
+        <lucene.version>4.7.0</lucene.version>
         <tests.jvms>1</tests.jvms>
         <tests.shuffle>true</tests.shuffle>
         <tests.output>onerror</tests.output>

--- a/src/main/groovy/org/elasticsearch/groovy/client/GIndicesAdminClient.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/client/GIndicesAdminClient.groovy
@@ -50,9 +50,9 @@ import org.elasticsearch.action.admin.indices.optimize.OptimizeResponse
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequestBuilder
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsRequest
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsRequestBuilder
-import org.elasticsearch.action.admin.indices.settings.UpdateSettingsResponse
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequestBuilder
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsResponse
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequestBuilder
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse

--- a/src/main/groovy/org/elasticsearch/groovy/client/action/GActionFuture.java
+++ b/src/main/groovy/org/elasticsearch/groovy/client/action/GActionFuture.java
@@ -20,7 +20,7 @@
 package org.elasticsearch.groovy.client.action;
 
 import groovy.lang.Closure;
-import org.elasticsearch.ElasticSearchException;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ListenableActionFuture;
@@ -93,19 +93,19 @@ public class GActionFuture<T> implements ListenableActionFuture<T>, ActionListen
         return actionGet();
     }
 
-    public T response(String timeout) throws ElasticSearchException {
+    public T response(String timeout) throws ElasticsearchException {
         return actionGet(timeout);
     }
 
-    public T response(long timeoutMillis) throws ElasticSearchException {
+    public T response(long timeoutMillis) throws ElasticsearchException {
         return actionGet(timeoutMillis);
     }
 
-    public T response(TimeValue timeout) throws ElasticSearchException {
+    public T response(TimeValue timeout) throws ElasticsearchException {
         return actionGet(timeout);
     }
 
-    public T response(long timeout, TimeUnit unit) throws ElasticSearchException {
+    public T response(long timeout, TimeUnit unit) throws ElasticsearchException {
         return actionGet(timeout, unit);
     }
 
@@ -131,27 +131,27 @@ public class GActionFuture<T> implements ListenableActionFuture<T>, ActionListen
     }
 
     @Override
-    public T actionGet() throws ElasticSearchException {
+    public T actionGet() throws ElasticsearchException {
         return future.actionGet();
     }
 
     @Override
-    public T actionGet(String timeout) throws ElasticSearchException {
+    public T actionGet(String timeout) throws ElasticsearchException {
         return future.actionGet(timeout);
     }
 
     @Override
-    public T actionGet(long timeoutMillis) throws ElasticSearchException {
+    public T actionGet(long timeoutMillis) throws ElasticsearchException {
         return future.actionGet(timeoutMillis);
     }
 
     @Override
-    public T actionGet(long timeout, TimeUnit unit) throws ElasticSearchException {
+    public T actionGet(long timeout, TimeUnit unit) throws ElasticsearchException {
         return future.actionGet(timeout, unit);
     }
 
     @Override
-    public T actionGet(TimeValue timeout) throws ElasticSearchException {
+    public T actionGet(TimeValue timeout) throws ElasticsearchException {
         return future.actionGet(timeout);
     }
 

--- a/src/test/groovy/org/elasticsearch/groovy/test/client/BuilderActionsTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/test/client/BuilderActionsTests.groovy
@@ -72,9 +72,16 @@ class BuilderActionsTests {
 
         node.client.admin.indices.refresh {}.actionGet()
 
-        def countR = node.client.prepareCount('test').setQuery({
-            term(test: 'value')
-        }).gexecute()
+
+        def theQuery = new org.elasticsearch.groovy.common.xcontent.GXContentBuilder().buildAsBytes {
+            query {
+                term {
+                    test = 'value'
+                }
+            }
+        }
+
+        def countR = node.client.prepareCount('test').setSource(theQuery).gexecute()
 
         assertThat countR.response.count, equalTo(1l)
 

--- a/src/test/groovy/org/elasticsearch/groovy/test/client/SimpleActionsTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/test/client/SimpleActionsTests.groovy
@@ -116,14 +116,18 @@ class SimpleActionsTests {
         refresh = node.client.admin.indices.refresh {}
         assertThat refresh.response.failedShards, equalTo(0)
 
-        def count = node.client.count {
-            indices 'test'
-            types 'type1'
+        def theQuery = new org.elasticsearch.groovy.common.xcontent.GXContentBuilder().buildAsBytes {
             query {
                 term {
                     test = 'value'
                 }
             }
+        }
+
+        def count = node.client.count {
+            indices 'test'
+            types 'type1'
+            source theQuery
         }
         assertThat count.response.failedShards, equalTo(0)
         assertThat count.response.count, equalTo(1l)
@@ -176,11 +180,17 @@ class SimpleActionsTests {
         assertThat search.response.hits.totalHits, equalTo(1l)
         assertThat search.response.hits[0].source.test, equalTo('new value')
 
+        def deleteByQueryQuery = new org.elasticsearch.groovy.common.xcontent.GXContentBuilder().buildAsBytes {
+            query {
+                term {
+                    test = 'value'
+                }
+            }
+        }
+
         def deleteByQuery = node.client.deleteByQuery {
             indices 'test'
-            query {
-                term(test: 'value')
-            }
+            source deleteByQueryQuery
         }
         assertThat deleteByQuery.response.indices.test.failedShards, equalTo(0)
 


### PR DESCRIPTION
Minor fixes to make the tests works again.

TODO: because of changes in the `CountRequestBuilder` we can call the `setQuery` method any more... we need to discuss if it makes sense to add the relevant methods back or if we are good using the source here.
