### PR TITLE
Adding Closure and XContentBuilder extensions

### DIFF
--- a/src/main/groovy/org/elasticsearch/groovy/ClosureExtensions.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/ClosureExtensions.groovy
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.groovy
+
+/**
+ * {@code ClosureExtensions} adds convenient behaviors to Groovy's {@link Closure} class, such as the ability to convert
+ * a {@code Closure} into a {@link Map} with {@link String} keys and {@link Object} values.
+ */
+class ClosureExtensions {
+    /**
+     * Convert the self-referenced {@link Closure} into a {@link Map} with {@link String} keys as {@link Object} values.
+     * <pre>
+     * Map&lt;String, Object&gt; closureMap = {
+     *   name {
+     *     first = "firstName"
+     *     last = "lastName"
+     *   }
+     *   nested {
+     *     object {
+     *       property = "value"
+     *     }
+     *   }
+     * }.asMap()
+     * </pre>
+     *
+     * @param self The {@code this} reference for the {@link Closure}
+     * @return Never {@code null}. Can be {@link Map#isEmpty() empty}.
+     * @throws NullPointerException if {@code self} is {@code null}
+     * @see ClosureToMapConverter#mapClosure(Closure)
+     */
+    static Map<String, Object> asMap(Closure self) {
+        ClosureToMapConverter.mapClosure(self)
+    }
+}

--- a/src/main/groovy/org/elasticsearch/groovy/ClosureToMapConverter.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/ClosureToMapConverter.groovy
@@ -1,0 +1,228 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.groovy
+
+/**
+ * {@code ClosureToMapConverter} serves as a utility to convert {@link Closure}s into {@link Map}s with {@link String}
+ * keys and {@link Object} values. The values can be {@link List}s, {@link Map}s, or other values (normal objects). In
+ * general, this serves as a convenient way to load JSON-like syntax in Groovy and convert it into a format usable by
+ * Elasticsearch.
+ * <pre>
+ * Map&lt;String, Object&gt; map = mapClosure {
+ *   name {
+ *     first = "Example"
+ *     middle = ["First", "Second"]
+ *     last = "Name"
+ *   }
+ *   details {
+ *     nested {
+ *       user_id = 1234
+ *       timestamp = new Date()
+ *     }
+ *   }
+ * }
+ * </pre>
+ * This class is added to {@link Closure}s automatically via the {@link ClosureExtensions} class, so the above code can
+ * be slightly simplified by avoiding the static import of {@link ClosureToMapConverter#mapClosure} and instead using
+ * the {@link ClosureExtensions#asMap(Closure)} extension method.
+ * <pre>
+ * Map&lt;String, Object&gt; map = {
+ *   name {
+ *     first = "Example"
+ *     middle = ["First", "Second"]
+ *     last = "Name"
+ *   }
+ *   details {
+ *     nested {
+ *       user_id = 1234
+ *       timestamp = new Date()
+ *     }
+ *   }
+ * }.asMap()
+ * </pre>
+ * It's important to note that the field name's can be specified as methods <em>or</em> properties. This means that
+ * <pre>
+ * {
+ *   name {
+ *     first "Example"
+ *   }
+ * }
+ * </pre>
+ * is treated the same way as
+ * <pre>
+ * {
+ *   name = {
+ *     first = "Example"
+ *   }
+ * }
+ * </pre>
+ * Mixing the two styles is allowed, but consistency is naturally very important for code readability.
+ * <p />
+ * Instances should never be reused. This class is not thread safe (only invoke it once from a single thread).
+ * @see ClosureExtensions#asMap(Closure)
+ */
+class ClosureToMapConverter {
+    /**
+     * Convert the {@code closure} into a {@link Map}.
+     *
+     * @param closure The closure to convert.
+     * @return Never {@code null}. Can be {@link Map#isEmpty() empty}.
+     */
+    static Map<String, Object> mapClosure(Closure closure) {
+        new ClosureToMapConverter(closure).convert()
+    }
+
+    /**
+     * Convert the passed in {@code value} into an object that is not a {@link Closure}, and convert any
+     * {@link Collection}s into {@link List}s.
+     * <p />
+     * This will recursively call itself as necessary.
+     *
+     * @param value The incoming parameter to convert if necessary ({@link Closure}s and {@link Collection}s)
+     * @return {@code value} as-is unless it is a {@link Closure} or {@link Collection}. Otherwise the unraveled
+     *         value of those objects.
+     */
+    private static Object convertValue(Object value) {
+        Object ret = value
+
+        // enable nested objects
+        if (value instanceof Closure) {
+            // avoid overwriting this instance's map
+            ret = mapClosure(value)
+        }
+        // unravel collections into a List
+        else if (value instanceof Collection) {
+            // use _this_ method by passing its method address to be invoked
+            ret = ((Collection)value).collect(ClosureToMapConverter.&convertValue)
+        }
+        // unravel arrays into a List (note: this hits native arrays like int[])
+        else if (value instanceof Object[] || (value != null && value.getClass().isArray())) {
+            ret = (value as List).collect(ClosureToMapConverter.&convertValue)
+        }
+
+        ret
+    }
+
+    /**
+     * The unraveled {@link Closure} after calling {@link #convert()}.
+     */
+    private final Map<String, Object> map = [:]
+    /**
+     * The closure that is unraveled into the {@link #map}.
+     */
+    final Closure closure
+
+    /**
+     * Construct a new {@link ClosureToMapConverter} that delegates the {@code closure} to call the constructed
+     * instance ({@code this}) when it is invoked. These calls are used to unravel the {@code closure} into the
+     * {@link #map}.
+     *
+     * @param closure The {@link Closure} to convert into a {@link Map}.
+     * @throws NullPointerException if {@code closure} is {@code null}
+     */
+    private ClosureToMapConverter(Closure closure) {
+        // required
+        this.closure = closure
+
+        // When looking up properties and invoking methods, it first looks at the delegate (THIS) for the value. If
+        //  the delegate (THIS) does not have it, then it will check the owner for the value (effectively the closure).
+        closure.delegate = this
+        // Note: Using OWNER_FIRST (the default) does not work except for non-nested closures.
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+    }
+
+    /**
+     * Trigger the conversion of the {@link #closure} to the {@link #map}.
+     * <p />
+     * This method should only be invoked once.
+     *
+     * @return Never {@code null}. {@link Map#isEmpty() Empty} if the {@code closure} does not assign any properties.
+     */
+    Map<String, Object> convert() {
+        // invoke the closure, thus triggering calls to the delegate (this)
+        closure.call()
+
+        map
+    }
+
+    /**
+     * Called when the {@link #closure} is delegating to {@code this} isntance for method invocations. For example
+     * <pre>
+     * { username "kimchy" }
+     * </pre>
+     * The above {@link Closure} would pass a {@code methodName} set to "username" and {@code args} as "kimchy"
+     * within a single element {@code Object[]}.
+     * <pre>
+     * {
+     *   user {
+     *     id 1234
+     *     name "kimchy"
+     *   }
+     * }
+     * </pre>
+     * This {@link Closure} would pass a {@code methodName} set to "user" and {@code args} as the user closure within
+     * a single element {@code Object[]}. A nested invocation of that closure would pass a {@code methodName} of
+     * "id" and {@code args} as 1234 within a single element {@code Object[]}. A separate nested invocation of that
+     * closure would handle the "name" field.
+     */
+    @Override
+    Object invokeMethod(String methodName, Object args) {
+        Object value = args
+
+        // single element arrays are the most expected form:
+        // Map map = {
+        //   name {
+        //     value = "xyz"
+        //   }
+        // }
+        // methodName would be "name" and args would be the closure
+        if (args instanceof Object[] && args.size() == 1) {
+            value = args[0]
+        }
+
+        // assign the value of the would-be method
+        setProperty(methodName, value)
+
+        // return the value
+        getProperty(methodName)
+    }
+
+    /**
+     * Get the value defined in the {@link #map} with the {@code propertyName}.
+     *
+     * @param propertyName The map key
+     * @return {@code null} if undefined.
+     */
+    @Override
+    Object getProperty(String propertyName) {
+        map[propertyName]
+    }
+
+    /**
+     * Called when the {@link #closure} is delegating to {@code this} instance. For example
+     * <pre>
+     * { username = "kimchy" }
+     * </pre>
+     * The above {@link Closure} would pass a {@code propertyName} set to "username" and a {@code newValue} as "kimchy".
+     */
+    @Override
+    void setProperty(String propertyName, Object newValue) {
+        map[propertyName] = convertValue(newValue)
+    }
+}

--- a/src/main/groovy/org/elasticsearch/groovy/common/xcontent/XContentBuilderExtensions.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/common/xcontent/XContentBuilderExtensions.groovy
@@ -1,0 +1,246 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.groovy.common.xcontent
+
+import org.elasticsearch.common.bytes.BytesReference
+import org.elasticsearch.common.io.BytesStream
+import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.common.xcontent.XContentBuilderString
+import org.elasticsearch.common.xcontent.XContentFactory
+import org.elasticsearch.common.xcontent.XContentGenerator
+import org.elasticsearch.common.xcontent.XContentType
+
+/**
+ * {@link XContentBuilderExtensions} adds Groovy-friendly extensions to {@link XContentBuilder} as well as directly to
+ * {@link Closure}s.
+ * <p />
+ * In particular, this adds the ability to convert a {@link Closure} into a {@link Map} to a {@link XContentBuilder} to
+ * enable effortless conversion:
+ * <pre>
+ * String json = XContentFactory.contentBuilder(XContentType.JSON).map {
+ *   name = {
+ *     first = "FirstName"
+ *     last = "LastName"
+ *   }
+ *   // Not necessarily the recommended way to make a Date object:
+ *   dob = new SimpleDateFormat("yyyy-MMM-dd").parse("2014-NOV-01")
+ *   address = {
+ *     street1 = "Street"
+ *     city = "City"
+ *     state = "State"
+ *     country = "Country"
+ *     postalCode = "12345"
+ *   }
+ * }.string
+ * </pre>
+ * Using the extensions provided here, this can be reduced even further to:
+ * <pre>
+ * String json = {
+ *   name = {
+ *     first = "FirstName"
+ *     last = "LastName"
+ *   }
+ *   // Not necessarily the recommended way to make a Date object:
+ *   dob = new SimpleDateFormat("yyyy-MMM-dd").parse("2014-NOV-01")
+ *   address = {
+ *     street1 = "Street"
+ *     city = "City"
+ *     state = "State"
+ *     country = "Country"
+ *     postalCode = "12345"
+ *   }
+ * }.asJsonString()
+ * </pre>
+ */
+class XContentBuilderExtensions {
+    /**
+     * Convert the {@link Closure} into a {@code Map} and return the {@link org.elasticsearch.common.xcontent.XContentType#JSON JSON} {@code byte}
+     * equivalent.
+     *
+     * @param self The {@code this} reference for the {@link Closure}
+     * @param type The type of {@code XContent} to create in byte form
+     * @return Never {@code null}.
+     * @throws NullPointerException if {@code self} is {@code null}
+     * @throws org.elasticsearch.ElasticsearchIllegalArgumentException if {@code type} is unrecognized
+     * @throws IOException if any error occurs while mapping the {@link Closure}
+     */
+    static byte[] asJsonBytes(Closure self) throws IOException {
+        buildBytes(self, XContentType.JSON)
+    }
+
+    /**
+     * Convert the {@link Closure} into a {@code Map} and return the {@link XContentType#JSON JSON} string equivalent.
+     *
+     * @param self The {@code this} reference for the {@link Closure}
+     * @param type The type of {@code XContent} to create in byte form
+     * @return Never blank.
+     * @throws NullPointerException if {@code self} is {@code null}
+     * @throws org.elasticsearch.ElasticsearchIllegalArgumentException if {@code type} is unrecognized
+     * @throws IOException if any error occurs while mapping the {@link Closure}
+     */
+    static String asJsonString(Closure self) throws IOException {
+        buildString(self, XContentType.JSON)
+    }
+
+    /**
+     * Create {@code XContentBuilder} with the specified {@code type} containing the {@code Map}ped form of the
+     * {@link Closure}.
+     *
+     * @param self The {@code this} reference for the {@link Closure}
+     * @param type The type of {@code XContent} to create
+     * @return Never {@code null}.
+     * @throws NullPointerException if {@code self} is {@code null}
+     * @throws org.elasticsearch.ElasticsearchIllegalArgumentException if {@code type} is unrecognized
+     * @throws IOException if any error occurs while mapping the {@link Closure}
+     */
+    static XContentBuilder build(Closure self, XContentType type) throws IOException {
+        XContentFactory.contentBuilder(type).map(self)
+    }
+
+    /**
+     * Convert the {@link Closure} into a {@code Map}, and create {@code XContent} with the specified {@code type} as a
+     * {@code byte[]}.
+     *
+     * @param self The {@code this} reference for the {@link Closure}
+     * @param type The type of {@code XContent} to create in byte form
+     * @return Never {@code null}.
+     * @throws NullPointerException if {@code self} is {@code null}
+     * @throws org.elasticsearch.ElasticsearchIllegalArgumentException if {@code type} is unrecognized
+     * @throws IOException if any error occurs while mapping the {@link Closure}
+     */
+    static byte[] buildBytes(Closure self, XContentType type) throws IOException {
+        build(self, type).bytes().array()
+    }
+
+    /**
+     * Convert the {@link Closure} into a {@code Map}, and create {@code XContent} with the specified {@code type} as a
+     * {@code byte[]}.
+     *
+     * @param self The {@code this} reference for the {@link Closure}
+     * @param type The type of {@code XContent} to create in byte form
+     * @return Never {@code null}.
+     * @throws NullPointerException if {@code self} is {@code null}
+     * @throws org.elasticsearch.ElasticsearchIllegalArgumentException if {@code type} is unrecognized
+     * @throws IOException if any error occurs while mapping the {@link Closure}
+     */
+    static String buildString(Closure self, XContentType type) throws IOException {
+        build(self, type).string()
+    }
+
+    /**
+     * Close the {@link XContentBuilder} and get the result as a {@code byte} array in the preset {@code XContentType}.
+     *
+     * @param self The {@code this} reference for the {@link XContentBuilder}
+     * @return Always {@link XContentBuilder#bytes()}.
+     * @throws NullPointerException if {@code self} is {@code null}
+     */
+    static BytesReference getBytes(XContentBuilder self) {
+        self.bytes()
+    }
+
+    /**
+     * Close the {@link XContentBuilder} and get the result as a {@link BytesStream} in the preset {@code XContentType}.
+     *
+     * @param self The {@code this} reference for the {@link XContentBuilder}
+     * @return Always {@link XContentBuilder#bytesStream()}.
+     * @throws NullPointerException if {@code self} is {@code null}
+     */
+    static BytesStream getBytesStream(XContentBuilder self) {
+        self.bytesStream()
+    }
+
+    /**
+     * Get the internal {@link XContentGenerator} of the {@link XContentBuilder}.
+     * <p />
+     * Note: This does <em>not</em> close the {@link XContentBuilder#generator()}.
+     *
+     * @param self The {@code this} reference for the {@link XContentBuilder}
+     * @return Always {@link XContentBuilder#generator()}.
+     * @throws NullPointerException if {@code self} is {@code null}
+     */
+    static XContentGenerator getGenerator(XContentBuilder self) {
+        self.generator()
+    }
+
+
+    /**
+     * Get the internal {@link OutputStream} of the {@link XContentBuilder}.
+     * <p />
+     * Note: This does <em>not</em> close the {@link XContentBuilder#generator()}.
+     *
+     * @param self The {@code this} reference for the {@link XContentBuilder}
+     * @return Always {@link XContentBuilder#stream()}.
+     * @throws NullPointerException if {@code self} is {@code null}
+     */
+    static OutputStream getStream(XContentBuilder self) {
+        self.stream()
+    }
+
+    /**
+     * Close the {@link XContentBuilder} and get the result as a {@link String} in the preset {@code XContentType}.
+     *
+     * @param self The {@code this} reference for the {@link XContentBuilder}
+     * @return Always {@link XContentBuilder#string()}.
+     * @throws NullPointerException if {@code self} is {@code null}
+     */
+    static String getString(XContentBuilder self) {
+        self.string()
+    }
+
+    /**
+     * Convert the {@code closure} into a {@link Map} and call {@link XContentBuilder#field(String, Map)}, effectively
+     * setting the {@code name} to the defined sub-object.
+     *
+     * @param self The {@code this} reference for the {@link XContentBuilder}
+     * @param closure The closure to convert to a map and add to the builder
+     * @return Always {@code self}.
+     * @throws NullPointerException if any parameter is {@code null}
+     * @throws IOException if any error occurs while adding the field
+     */
+    static XContentBuilder field(XContentBuilder self, String name, Closure closure) throws IOException {
+        self.field(name, closure.asMap())
+    }
+
+    /**
+     * Convert the {@code closure} into a {@link Map} and call {@link XContentBuilder#field(String, Map)}, effectively
+     * setting the {@code name} to the defined sub-object.
+     *
+     * @param self The {@code this} reference for the {@link XContentBuilder}
+     * @param closure The closure to convert to a map and add to the builder
+     * @return Always {@code self}.
+     * @throws NullPointerException if any parameter is {@code null}
+     * @throws IOException if any error occurs while adding the field
+     */
+    static XContentBuilder field(XContentBuilder self, XContentBuilderString name, Closure closure) throws IOException {
+        self.field(name, closure.asMap())
+    }
+
+    /**
+     * Convert the {@code closure} into a {@link Map} and {@link XContentBuilder#map} it to {@code self}.
+     *
+     * @param self The {@code this} reference for the {@link XContentBuilder}
+     * @param closure The closure to convert to a map and add to the builder
+     * @return Always {@code self}.
+     * @throws NullPointerException if any parameter is {@code null}
+     * @throws IOException if any error occurs while adding the map
+     */
+    static XContentBuilder map(XContentBuilder self, Closure closure) throws IOException {
+        self.map(closure.asMap())
+    }
+}

--- a/src/main/groovy/org/elasticsearch/groovy/node/NodeBuilderExtensions.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/node/NodeBuilderExtensions.groovy
@@ -21,7 +21,6 @@ package org.elasticsearch.groovy.node
 import org.elasticsearch.ElasticsearchIllegalArgumentException
 import org.elasticsearch.common.settings.ImmutableSettings
 import org.elasticsearch.common.settings.loader.JsonSettingsLoader
-import org.elasticsearch.groovy.common.xcontent.GXContentBuilder
 import org.elasticsearch.node.NodeBuilder
 
 /**
@@ -59,13 +58,11 @@ class NodeBuilderExtensions {
      * @throws ElasticsearchIllegalArgumentException if the {@code settings} fail to parse as JSON
      */
     static NodeBuilder settings(NodeBuilder self, Closure settings) {
-        byte[] settingsBytes = new GXContentBuilder().buildAsBytes(settings)
-
         try {
-            self.settings().put(new JsonSettingsLoader().load(settingsBytes))
+            self.settings().put(new JsonSettingsLoader().load(settings.asJsonBytes()))
         }
         catch (IOException e) {
-            throw new ElasticsearchIllegalArgumentException("Closure fail to map to JSON.", e)
+            throw new ElasticsearchIllegalArgumentException("Closure failed to map to valid JSON.", e)
         }
 
         self

--- a/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
+++ b/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
@@ -33,10 +33,11 @@ moduleVersion = 1.0
 # first parameter the implicit this argument in normal class-level methods).
 #
 extensionClasses = \
+  org.elasticsearch.groovy.ClosureExtensions,\
   org.elasticsearch.groovy.client.AdminClientExtensions,\
   org.elasticsearch.groovy.client.ClientExtensions,\
   org.elasticsearch.groovy.client.ClusterAdminClientExtensions,\
   org.elasticsearch.groovy.client.IndicesAdminClientExtensions,\
   org.elasticsearch.groovy.node.NodeBuilderExtensions,\
-  org.elasticsearch.groovy.node.NodeExtensions
-
+  org.elasticsearch.groovy.node.NodeExtensions,\
+  org.elasticsearch.groovy.common.xcontent.XContentBuilderExtensions

--- a/src/test/groovy/org/elasticsearch/groovy/ClosureExtensionsTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/ClosureExtensionsTests.groovy
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.groovy
+
+import org.elasticsearch.test.ElasticsearchTestCase
+
+import org.junit.Test
+
+/**
+ * Tests {@link ClosureExtensions}.
+ * <p />
+ * These tests assume that {@link ClosureToMapConverter} is appropriately tested.
+ */
+class ClosureExtensionsTests extends ElasticsearchTestCase {
+    @Test
+    void testAsMap() {
+        String firstName = randomAsciiOfLengthBetween(1, 8)
+        String lastName = randomAsciiOfLengthBetween(1, 8)
+
+        Map<String, Object> map = ClosureExtensions.asMap {
+            name {
+                first = firstName
+                last = lastName
+            }
+        }
+
+        assert map.name.first == firstName
+        assert map.name.last == lastName
+    }
+
+    @Test
+    void testExtensionModuleConfigured() {
+        String randomName = randomAsciiOfLengthBetween(1, 8)
+
+        assert { name = randomName }.asMap().name == randomName
+    }
+}

--- a/src/test/groovy/org/elasticsearch/groovy/ClosureToMapConverterTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/ClosureToMapConverterTests.groovy
@@ -1,0 +1,192 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.groovy
+
+import org.elasticsearch.test.ElasticsearchTestCase
+
+import org.junit.Test
+
+import static org.elasticsearch.groovy.ClosureToMapConverter.mapClosure
+
+/**
+ * Tests {@link ClosureToMapConverter}.
+ */
+class ClosureToMapConverterTests extends ElasticsearchTestCase {
+    @Test
+    void testFlatMapConversion() {
+        long value = randomLong()
+        String string = randomAsciiOfLengthBetween(1, 16)
+        Date now = new Date()
+        boolean bool = randomBoolean()
+
+        Map<String, Object> map = mapClosure {
+            id = value
+            name = string
+            date = now
+            valid = bool
+            // ensure methods work
+            method = randomBoolean()
+        }
+
+        assert map.id == value
+        assert map.name == string
+        assert map.date == now
+        assert map.valid == bool
+        assert map.method instanceof Boolean
+    }
+
+    @Test
+    void testListMapConversion() {
+        long value = randomLong()
+        List values = [randomAsciiOfLengthBetween(1, 8), randomLong(), randomBoolean()]
+
+        Map<String, Object> map = mapClosure {
+            id = value
+            list = values
+        }
+
+        assert map.id == value
+        assert map.list == values
+    }
+
+    @Test
+    void testNestedPropertyMapConversion() {
+        long value = randomLong()
+        String firstName = randomAsciiOfLengthBetween(1, 8)
+        String lastName = randomAsciiOfLengthBetween(1, 8)
+        Date now = new Date()
+        List values = [randomAsciiOfLengthBetween(1, 8), randomLong(), randomBoolean()]
+
+        Map<String, Object> map = mapClosure {
+            id = value
+            name = {
+                first = firstName
+                last = lastName
+            }
+            date = now
+            list = values
+        }
+
+        assert map.id == value
+        assert map.name instanceof Map
+        assert map.name.first == firstName
+        assert map.name.last == lastName
+        assert map.date == now
+        assert map.list == values
+        // ensure there is no double-coverage
+        assert map.first == null
+        assert map.last == null
+    }
+
+    @Test
+    void testNestedMethodMapConversion() {
+        long value = randomLong()
+        String firstName = randomAsciiOfLengthBetween(1, 8)
+        String lastName = randomAsciiOfLengthBetween(1, 8)
+        Date now = new Date()
+        List values = [randomAsciiOfLengthBetween(1, 8), randomLong(), randomBoolean()]
+
+        Map<String, Object> map = mapClosure {
+            id value
+            name {
+                first firstName
+                last lastName
+            }
+            date now
+            list values
+        }
+
+        assert map.id == value
+        assert map.name instanceof Map
+        assert map.name.first == firstName
+        assert map.name.last == lastName
+        assert map.date == now
+        assert map.list == values
+        // ensure there is no double-coverage
+        assert map.first == null
+        assert map.last == null
+    }
+
+    @Test
+    void testComplexMapConversion() {
+        long value = randomLong()
+        String firstName = randomAsciiOfLengthBetween(1, 8)
+        String lastName = randomAsciiOfLengthBetween(1, 8)
+        Date start = new Date(randomLong())
+        Date now = new Date()
+        double number = randomDouble()
+        List methodValues = [randomInt(), randomFloat()]
+        List values = [randomAsciiOfLengthBetween(1, 8), randomLong(), randomBoolean()]
+        int[] ints = [randomInt(), randomInt()] as int[]
+        Map mapValues = [key : randomInt()]
+
+        Set setValues = [] as Set
+        int setSize = randomInt(8)
+
+        // random number of values
+        for (int i = 0; i < setSize; ++i) {
+            setValues.add(randomDouble())
+        }
+
+        Map<String, Object> map = mapClosure {
+            id = value
+            user {
+                name {
+                    first = firstName
+                    middle = [randomAsciiOfLengthBetween(1, 8), randomAsciiOfLengthBetween(1, 8)]
+                    last = lastName
+                }
+                dates = {
+                    // same fieldname as name
+                    first = start
+                }
+            }
+            percent = number
+            collections {
+                list = values
+                map = mapValues
+                // will be converted to a list:
+                set = setValues
+            }
+            timestamp = now
+            // single method invocation with two parameters:
+            method methodValues[0], methodValues[1]
+            array randomLong(), randomDouble()
+            intArray ints
+        }
+
+        assert map.id == value
+        assert map.user.name.first == firstName
+        assert map.user.name.middle.size() == 2
+        assert map.user.name.last == lastName
+        assert map.user.dates.first == start
+        assert map.percent == number
+        assert map.collections.list == values
+        assert map.collections.map == mapValues
+        assert map.collections.set == setValues.collect()
+        assert map.timestamp == now
+        assert map.method == methodValues
+        assert map.array instanceof List
+        assert map.array.size() == 2
+        assert map.intArray instanceof List
+        assert map.intArray == ints as List
+        // observed while developing, so this ensures that it isn't being defined
+        assert map.user.randomAsciiOfLengthBetween == null
+    }
+}

--- a/src/test/groovy/org/elasticsearch/groovy/common/xcontent/XContentBuilderExtensionsTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/common/xcontent/XContentBuilderExtensionsTests.groovy
@@ -1,0 +1,144 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.elasticsearch.groovy.common.xcontent
+
+import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.common.xcontent.XContentFactory
+import org.elasticsearch.common.xcontent.XContentParser
+import org.elasticsearch.common.xcontent.XContentType
+import org.elasticsearch.test.ElasticsearchTestCase
+
+import org.junit.Test
+
+/**
+ * Tests {@link XContentBuilderExtensions}.
+ */
+class XContentBuilderExtensionsTests extends ElasticsearchTestCase {
+    /**
+     * Get a random {@link XContentType} to ensure all types work.
+     */
+    private final XContentType type = XContentType.values()[randomInt(XContentType.values().length - 1)]
+
+    /**
+     * Reproducible number.
+     */
+    private final long value = randomLong()
+    /**
+     * Reproducible string.
+     */
+    private final String nestedName = randomAsciiOfLengthBetween(1, 8)
+
+    /**
+     * {@link Closure} used to test mappings.
+     */
+    private final Closure closure = {
+        id = value
+        nested {
+            name = nestedName
+        }
+    }
+
+    /**
+     * {@link XContentBuilder} to ensure functionality.
+     */
+    private final XContentBuilder jsonBuilder = XContentFactory.contentBuilder(XContentType.JSON)
+
+    @Test
+    void testAsJsonBytes() {
+        byte[] bytes = XContentBuilderExtensions.asJsonBytes(closure)
+        XContentParser jsonParser = XContentType.JSON.xContent().createParser(bytes)
+
+        assert closure.asMap() == jsonParser.mapAndClose()
+    }
+
+    @Test
+    void testAsJsonString() {
+        String string = XContentBuilderExtensions.asJsonString(closure)
+        XContentParser jsonParser = XContentType.JSON.xContent().createParser(string)
+
+        assert closure.asMap() == jsonParser.mapAndClose()
+    }
+
+    @Test
+    void testBuild() {
+        XContentBuilder builder = XContentBuilderExtensions.build(closure, type)
+
+        assert type == builder.contentType()
+        assert closure.asMap() == type.xContent().createParser(builder.bytes()).mapAndClose()
+    }
+
+    @Test
+    void testBuildBytes() {
+        byte[] bytes = XContentBuilderExtensions.buildBytes(closure, XContentType.SMILE)
+
+        assert closure.asMap() == XContentType.SMILE.xContent().createParser(bytes).mapAndClose()
+    }
+
+    @Test
+    void testBuildString() {
+        // avoid using SMILE because it will [expectedly] fail with strings (so YAML was picked to avoid using hitting
+        //  SMILE and reusing JSON)
+        String string = XContentBuilderExtensions.buildString(closure, XContentType.YAML)
+
+        assert closure.asMap() == XContentType.YAML.xContent().createParser(string).mapAndClose()
+    }
+
+    @Test
+    void testGetBytes() {
+        assert XContentBuilderExtensions.getBytes(jsonBuilder) == jsonBuilder.bytes()
+    }
+
+    @Test
+    void testGetByteStream() {
+        assert XContentBuilderExtensions.getBytesStream(jsonBuilder) == jsonBuilder.bytesStream()
+    }
+
+    @Test
+    void testGetGenerator() {
+        assert XContentBuilderExtensions.getGenerator(jsonBuilder) == jsonBuilder.generator()
+    }
+
+    @Test
+    void testGetStream() {
+        assert XContentBuilderExtensions.getStream(jsonBuilder) == jsonBuilder.stream()
+    }
+
+    @Test
+    void testGetString() {
+        assert XContentBuilderExtensions.getString(jsonBuilder) == jsonBuilder.string()
+    }
+
+    @Test
+    void testExtensionModuleConfigured() {
+        // map the same closure
+        XContentBuilder arbitraryBuilder = XContentFactory.contentBuilder(type).map(closure)
+        XContentBuilder jsonBuilder = XContentFactory.contentBuilder(XContentType.JSON).map(closure)
+
+        assert closure.asJsonString() == jsonBuilder.string()
+        assert closure.asJsonBytes() == jsonBuilder.bytes().array()
+        assert closure.buildString(type) == arbitraryBuilder.string()
+        assert closure.build(type).string() == arbitraryBuilder.string()
+        assert closure.buildBytes(type) == arbitraryBuilder.bytes().array()
+        assert jsonBuilder.bytes() == jsonBuilder.getBytes()
+        assert jsonBuilder.bytesStream() == jsonBuilder.getBytesStream()
+        assert jsonBuilder.generator() == jsonBuilder.getGenerator()
+        assert jsonBuilder.stream() == jsonBuilder.getStream()
+        assert jsonBuilder.string() == jsonBuilder.getString()
+    }
+}

--- a/src/test/groovy/org/elasticsearch/groovy/node/NodeBuilderExtensionsTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/node/NodeBuilderExtensionsTests.groovy
@@ -22,7 +22,7 @@ import org.elasticsearch.common.settings.ImmutableSettings
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.node.Node
 import org.elasticsearch.node.NodeBuilder
-import org.elasticsearch.test.ElasticsearchIntegrationTest
+import org.elasticsearch.test.ElasticsearchTestCase
 
 import org.junit.Test
 
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when
 /**
  * Tests {@link NodeBuilderExtensions}.
  */
-class NodeBuilderExtensionsTests extends ElasticsearchIntegrationTest {
+class NodeBuilderExtensionsTests extends ElasticsearchTestCase {
     /**
      * Tested {@link NodeBuilder}.
      */

--- a/src/test/groovy/org/elasticsearch/groovy/node/NodeExtensionsTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/node/NodeExtensionsTests.groovy
@@ -21,7 +21,7 @@ package org.elasticsearch.groovy.node
 import org.elasticsearch.client.Client
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.node.Node
-import org.elasticsearch.test.ElasticsearchIntegrationTest
+import org.elasticsearch.test.ElasticsearchTestCase
 
 import org.junit.Test
 
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.when
 /**
  * Tests {@link NodeExtensions}.
  */
-class NodeExtensionsTests extends ElasticsearchIntegrationTest {
+class NodeExtensionsTests extends ElasticsearchTestCase {
     /**
      * Mock {@link Node} to ensure functionality.
      */


### PR DESCRIPTION
Adding extensions to `Closure`s and `XContentBuilder` to enable much simpler conversion of `Closure`s into `Map`s, and therefore into indexable data or queries.
- This removes the need for `GXContentBuilder` (effectively replaced by `ClosureToMapConverter` combined with extensions to `Closure`s for improved readability), but until other PRs are merged, it cannot be removed.

It adds support for converting a `Closure` into a `Map<String, Object>`.

``` groovy
Map<String, Object> map = {
  user {
    id = 1234
    name = "kimchy"
  }
  // same as tags = ["tag1", "tag2"] and tags ["tag1", "tag2"]
  tags "tag1", "tag2"
}.asMap()
```

Relatedly, it adds `XContentBuilder` extensions to simplify going directly to--say--JSON:

``` groovy
byte[] jsonBytes = {
  user {
    id = 1234
    name = "kimchy"
  }
  // same as tags = ["tag1", "tag2"] and tags ["tag1", "tag2"]
  tags "tag1", "tag2"
}.asJsonBytes()
```

as well as other formats

``` groovy
byte[] smileBytes = {
  user {
    id = 1234
    name = "kimchy"
  }
  // same as tags = ["tag1", "tag2"] and tags ["tag1", "tag2"]
  tags "tag1", "tag2"
}.buildBytes(XContentType.SMILE)
```

Closes #6
