### PR TITLE
Update to Elasticsearch 1.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Groovy Client for Elasticsearch
 ===============================
 
-The Elasticsearch Groovy Client project helps you to use Elasticsearch in Groovy projects. This Groovy client is
+The Elasticsearch Groovy client project helps you to use Elasticsearch in Groovy projects. This Groovy client is
 different from previous releases in that it inherently supports 100% of the Elasticsearch API for the supported version
 by using the Groovy extension feature with the Java Client. Literally anything possible in the same version of the Java
 Client is possible with the Groovy client, plus some Groovy-friendly extensions.
@@ -30,13 +30,13 @@ Besides the usage of `Closure`s, the above example should look very familiar to 
 Versions
 --------
 
-|     Groovy Client           |    elasticsearch    |  groovy  | Release date |
+|     Groovy Client           |    Elasticsearch    |  Groovy  | Release date |
 |-----------------------------|---------------------|----------|:------------:|
-| 1.3.4.0-SNAPSHOT            | 1.3.4               |  2.3.2   |  XXXX-XX-XX  |
+| 1.4.0.0-SNAPSHOT            | 1.4.0               |  2.3.2   |  XXXX-XX-XX  |
 
 Please read documentation relative to the version you are using:
 
-* [1.3.4.0-SNAPSHOT](https://github.com/elasticsearch/elasticsearch-groovy/blob/master/README.md)
+* [1.4.0.0-SNAPSHOT](https://github.com/elasticsearch/elasticsearch-groovy/blob/master/README.md)
 
 Adding to your Groovy projects
 ------------------------------
@@ -49,7 +49,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.elasticsearch:elasticsearch-groovy:1.3.4.0-SNAPSHOT'
+    compile 'org.elasticsearch:elasticsearch-groovy:1.4.0.0-SNAPSHOT'
 }
 ```
 
@@ -60,7 +60,7 @@ dependencies {
   <dependency>
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch-groovy</artifactId>
-    <version>1.3.4.0-SNAPSHOT</version>
+    <version>1.4.0.0-SNAPSHOT</version>
     <scope>compile</scope>
   </dependency>
 </dependencies>
@@ -72,10 +72,12 @@ Compiling Groovy Client
 To compile this code on your own, then run:
 
 ```bash
-$ mvn clean package -DskipTests
+$ gradle clean installDist
 ```
 
-In the longer term, there will be a Gradle build script to perform this action.
+This will skip all tests and place the compiled jar in
+`./build/install/elasticsearch-groovy/elasticsearch-groovy-{version}.jar`. It will package all dependencies (e.g., 
+`elasticsearch-{version}.jar`) into `./build/install/elasticsearch-groovy/lib`.
 
 Testing Groovy Client
 ---------------------
@@ -85,10 +87,13 @@ itself](http://www.elasticsearch.org/blog/elasticsearch-testing-qa-increasing-co
 tests and integration tests that this uses can be invoked with the same command:
 
 ```bash
-$ mvn clean test
+$ gradle clean test
 ```
 
-In the longer term, there will be a Gradle build script to perform this action.
+The various `tests.*` and `es.*` system properties that are used by Elasticsearch are also used by the Gradle build
+script. As a result, any recommendation that suggests running `mvn clean test -DsystemProp=xyz` can be replaced with
+`gradle clean test -DsystemProp=xyz` (the only change was from `mvn` to `gradle`). This _only_ applies to the Groovy
+client.
 
 Suggested Groovy Settings
 -------------------------
@@ -101,7 +106,7 @@ support for Java 5 and Java 6, which means that `invokedynamic` cannot be enable
 ### Compiling Groovy with `invokedynamic` support
 
 To support `invokedynamic` in your own Groovy project(s), at a minimum, you *must* include the `invokedynamic`-compiled
-Groovy jar, which Codehaus calls the `indy` (`in`voke`dy`namic) jar.
+Groovy jar, which the Groovy developers call the `indy` (`in`voke`dy`namic) jar.
 
 #### Gradle
 
@@ -133,7 +138,7 @@ dependencies {
 
 After including the `indy` jar, you now _only_ have an `invokedynamic`-compatible Groovy runtime. All internal Groovy
 calls will use `invokedynamic`, as will any other Groovy code compiled with `invokedynamic` support (e.g., the
-Elasticsearch Groovy Client), but _your_ code must also be compiled with `invokedynamic` support.
+Elasticsearch Groovy client), but _your_ code must also be compiled with `invokedynamic` support.
 
 #### Gradle
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,196 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+///////////////////////////////////////////////////
+//                                               //
+//                Gradle Plugins                 //
+//                                               //
+///////////////////////////////////////////////////
+
+apply plugin: 'groovy'
+apply plugin: 'java-library-distribution'
+
+///////////////////////////////////////////////////
+//                                               //
+//             Dependency Details                //
+//                                               //
+///////////////////////////////////////////////////
+
+/**
+ * Extension properties are a Gradle feature that allow "extra" variables to be added to a project in a predictable way.
+ * To define them, you must use the ".ext." go-between. Once defined, they are accessible directly from the associated
+ * {@code project} object.
+ * <p />
+ * For example, <code>project.ext.version = '1.2.3-SNAPSHOT'</code> could be accessed as {@code project.version}.
+ * Within <em>that</em> {@code project}'s build.gradle file, it can be accessed directly as {@code version}".
+ */
+project.ext {
+    // A map that is defined to contain version numbers for all dependencies in the current release.
+    versions = [
+            elasticsearch              : '1.4.0',
+            groovy                     : '2.3.2',
+            java                       : '1.7',
+            hamcrest                   : '1.3',
+            log4j                      : '1.2.17',
+            lucene                     : '4.10.2',
+            mockito                    : '1.10.5',
+            'randomizedtesting-runner' : '2.1.10'
+    ]
+
+    // A map defining shorthand names to reference external dependencies.
+    //
+    // Note: Strings must use double quotes to expand "${var}" into its actual value. '${var}' is literally that string.
+    //  Similarly, keys that have spaces or dashes in their name must be quoted (single or double).
+    externalDeps = [
+            // Test Dependencies
+            'elasticsearch-tests'      : "org.elasticsearch:elasticsearch:${versions.elasticsearch}:tests",
+            hamcrest                   : "org.hamcrest:hamcrest-all:${versions.hamcrest}",
+            'lucene-test-framework'    : "org.apache.lucene:lucene-test-framework:${versions.lucene}",
+            mockito                    : "org.mockito:mockito-core:${versions.mockito}",
+            'randomizedtesting-runner' : "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions['randomizedtesting-runner']}",
+            // Compile Dependencies
+            elasticsearch              : "org.elasticsearch:elasticsearch:${versions.elasticsearch}",
+            groovy                     : "org.codehaus.groovy:groovy-all:${versions.groovy}:indy",
+            // Test Runtime Dependencies
+            log4j                      : "log4j:log4j:${versions.log4j}"
+    ]
+}
+
+/**
+ * Dependent on Maven Central to retrieve all external dependencies.
+ */
+repositories {
+    mavenCentral()
+}
+
+/**
+ * Associate external dependencies with this project. Gradle only requires this step, and it does not require the
+ * {@code versions} and {@code externalDeps} {@code Map}s. I find that they make it much easier to eyeball what is
+ * happening as well as to find mistakes.
+ * <p />
+ * Where order does <em>not</em> matter for the dependencies, then they are sorted alphabetically.
+ */
+dependencies {
+    testCompile externalDeps['hamcrest'],
+            externalDeps['lucene-test-framework'],
+            externalDeps['mockito'],
+            externalDeps['randomizedtesting-runner'],
+            externalDeps['elasticsearch-tests'] // Must come after lucene-test-framework
+
+    compile externalDeps['elasticsearch'],
+            externalDeps['groovy']
+
+    testRuntime externalDeps['log4j']
+}
+
+// The minimum required Java version (this matches the Elasticsearch minimum Java version)
+// Note: If we could supply the minimum Java update, then we would specify this as 1.7.0_60 (or 7u60 for short).
+sourceCompatibility = versions.java
+
+///////////////////////////////////////////////////
+//                                               //
+//               Project Details                 //
+//                                               //
+///////////////////////////////////////////////////
+
+// Project details
+description = 'Official Groovy client for Elasticsearch'
+
+// The group of the project. This is the same group that represents the "org.elasticsearch" in the Maven repository.
+group = 'org.elasticsearch'
+// The Groovy client adds an extra subversion to the Elasticsearch version number so that it is immediately obvious what
+// version each release is compatible with.
+version = "${versions.elasticsearch}.0-SNAPSHOT"
+
+///////////////////////////////////////////////////
+//                                               //
+//             Build Customization               //
+//                                               //
+///////////////////////////////////////////////////
+
+// Allow the system property to override the environment variable. However, if the system property is not defined and
+// the environment variable is defined, then use the environment variable's value.
+//
+// It's worth pointing out that if neither are set, then it will use Elasticsearch's default value at runtime. This is
+// currently `true`.
+if (System.getProperty('es.node.local') == null && System.getenv('ES_TEST_LOCAL') != null) {
+    System.setProperty('es.node.local', System.getenv('ES_TEST_LOCAL'))
+}
+
+/**
+ * Configure Groovy compilation.
+ */
+tasks.withType(GroovyCompile) {
+    // Enable the usage of invokedynamic instructions in compiled Groovy code
+    // NOTE: This requires the "indy" version of the Groovy jar to take effect _and_ this is the reason that Java 7u60
+    //  or later is required by the Groovy client.
+    groovyOptions.optimizationOptions.indy = true
+}
+
+/**
+ * Pass on any system property that starts with "tests." or "es." to the test JVM.
+ * <p />
+ * For example, this includes "-Dtests.seed=3BE033A80EF93B56", which is used by the randomized runner to
+ * [unsurprisingly] seed a test so that it can be repeated with the same values each run. This is useful when the test
+ * fails.
+ * <p />
+ * To run tests the same way, with the same values (the seed), 100 times <em>or</em> until the first failure, then use
+ * the following command:
+ * <pre>
+ * $ gradle clean test -Dtests.seed=3BE033A80EF93B56 -Dtests.iters=100 -Dtests.failfast=true
+ * </pre>
+ * This can be very useful for when testing potential threading issues.
+ * <p />
+ * Note: Error output may suggest to run Maven for any test failure. Don't be fooled! Use the suggested system
+ * properties  with <em>this</em> Gradle build!
+ */
+tasks.withType(Test) {
+    // Expected System Properties, which all come from Elasticsearch / Lucene / Randomized Runner:
+    //
+    //  tests.shuffle
+    //  tests.verbose
+    //  tests.seed
+    //  tests.failfast
+    //  tests.iters
+    //  tests.maxfailures
+    //  tests.class   ; note this overlaps with the Gradle test filter feature (-Dtest.single=*)
+    //  tests.method
+    //  tests.nightly
+    //  tests.badapples
+    //  tests.weekly
+    //  tests.slow
+    //  tests.awaitsfix
+    //  tests.timeoutSuite
+    //  tests.showSuccess
+    //  tests.integration
+    //  tests.cluster_seed
+    //  tests.client.ratio
+    //  es.node.local OR environment variable ES_TEST_LOCAL
+    //  es.node.mode
+    //  es.logger.level
+    //  java.awt.headless
+
+    // Add any "tests." or "es." system properties to the test's JVM. These system properties control the randomized
+    // runner.
+    systemProperties System.properties.findAll { prop ->
+        ['tests.', 'es.', 'java.awt.headless'].any {
+            prop.key.startsWith(it)
+        }
+    }
+}

--- a/docs/overview.asciidoc
+++ b/docs/overview.asciidoc
@@ -1,0 +1,36 @@
+== Overview
+
+This is the official Groovy client for Elasticsearch.  It is designed to be 100% compatible with the matching release of
+Elasticsearch's official Java client, only adding features that make it more convenient to use in Groovy without losing
+_any_ of the core functionality.
+
+The Groovy client is able to maintain compatibility by using a Groovy
+http://groovy.codehaus.org/Creating+an+extension+module[feature known as Extension modules]. We make heavy use of this
+approach to extend the Java client _in place_ to maintain compatibility and simplicity.
+
+By taking this approach, every Elasticsearch Java client example works with the Groovy client and they can be extended
+easily to simplify development. In general, the Groovy client has a few core goals:
+
+1. Provide 100% compatibility with the Java client and therefore feature parity.
+2. Provide Groovy-friendly syntax where it improves the API.
+3. Avoid adding complexity for the sake of supporting Groovy.
+4. Avoid unnecessarily compromising the performance of the Java client for the sake of Groovy.
+
+=== Groovy and Java Requirements
+
+tl;dr Use Java 7u60 or later
+
+The Groovy client is a literal extension of the Java client and therefore it has all of the same requirements. One of
+the most pressing requirements is the version of Java that is required.
+
+Supported versions of the Elasticsearch Java client require Java 7 or later to be able to run with a recommendation to
+stay up-to-date with JVM releases, and to particularly avoid Java releases prior to Java 7 update 55. The Groovy client
+gets more specific due to a new Java instruction known as `invokedynamic`, or `indy` for short (__in__voke__dy__namic),
+which we take advantage of to get higher performance, lower memory usage, and even smaller jar files in some cases.
+
+With the `indy` requirement comes a http://groovy.codehaus.org/InvokeDynamic+support[further restriction on Java 7
+JVMs] from the Groovy maintainers. They recommend that you should never use Java versions 7u21 through 7u55 due to more
+than one https://bugs.openjdk.java.net/browse/JDK-8033669[JVM bug] (e.g.,
+https://bugs.openjdk.java.net/browse/JDK-8034024[here's another]).
+
+As a result, they explicitly suggest and our Groovy client implicitly requires Java 7u60 or later.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,38 @@
+# Licensed to Elasticsearch under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#################################################
+#                                               #
+#           Preset System Properties            #
+#                                               #
+#################################################
+#
+# Any system property can be explicitly overridden without touching this file by adding the system property on the
+# command line. For example:
+#
+#    $ gradle [tasks] -Djava.awt.headless=false
+#
+# Any environment variable can be overridden by simply having it defined in your environment.
+#
+
+# By default, assume that we want local test nodes.
+#
+# This can be overridden by supplying the corresponding environment variable _or_ -Des.node.local=false
+envES_TEST_LOCAL=true
+
+# It's unlikely that you will want to change this value and it is not intended to be overridden.
+systemProp.java.awt.headless=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The name of the Gradle project. It must be set in this file.
+//
+// This is used in lieu of the directory name, which has the same name by default.
+rootProject.name = 'elasticsearch-groovy'

--- a/src/main/groovy/org/elasticsearch/groovy/common/xcontent/XContentBuilderExtensions.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/common/xcontent/XContentBuilderExtensions.groovy
@@ -144,7 +144,8 @@ class XContentBuilderExtensions {
     }
 
     /**
-     * Close the {@link XContentBuilder} and get the result as a {@code byte} array in the preset {@code XContentType}.
+     * Close the {@link XContentBuilder} and get the resulting {@link BytesReference} in the preset
+     * {@code XContentType}.
      *
      * @param self The {@code this} reference for the {@link XContentBuilder}
      * @return Always {@link XContentBuilder#bytes()}.

--- a/src/test/groovy/org/elasticsearch/groovy/common/xcontent/XContentBuilderExtensionsTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/common/xcontent/XContentBuilderExtensionsTests.groovy
@@ -85,9 +85,9 @@ class XContentBuilderExtensionsTests extends ElasticsearchTestCase {
 
     @Test
     void testBuildBytes() {
-        byte[] bytes = XContentBuilderExtensions.buildBytes(closure, XContentType.SMILE)
+        byte[] bytes = XContentBuilderExtensions.buildBytes(closure, type)
 
-        assert closure.asMap() == XContentType.SMILE.xContent().createParser(bytes).mapAndClose()
+        assert closure.asMap() == type.xContent().createParser(bytes).mapAndClose()
     }
 
     @Test
@@ -131,10 +131,10 @@ class XContentBuilderExtensionsTests extends ElasticsearchTestCase {
         XContentBuilder jsonBuilder = XContentFactory.contentBuilder(XContentType.JSON).map(closure)
 
         assert closure.asJsonString() == jsonBuilder.string()
-        assert closure.asJsonBytes() == jsonBuilder.bytes().array()
+        assert closure.asJsonBytes() == jsonBuilder.bytes().toBytes()
         assert closure.buildString(type) == arbitraryBuilder.string()
         assert closure.build(type).string() == arbitraryBuilder.string()
-        assert closure.buildBytes(type) == arbitraryBuilder.bytes().array()
+        assert closure.buildBytes(type) == arbitraryBuilder.bytes().toBytes()
         assert jsonBuilder.bytes() == jsonBuilder.getBytes()
         assert jsonBuilder.bytesStream() == jsonBuilder.getBytesStream()
         assert jsonBuilder.generator() == jsonBuilder.getGenerator()


### PR DESCRIPTION
- In addition to modifying the Maven `pom`, this also adds the Gradle build that I have been using locally.
- The Maven build has hit a bug related to a long class name, likely triggered by how Groovy expands closures as anonymous classes under the hood.
  - As a result, I will likely be removing the Maven build soon.
- The Gradle build is shorter and, in my opinion, easier to read. It also matches the build tool traditionally used by Groovy projects.
