### PR TITLE
Adding requestAsync variants and deprecating request variants

### DIFF
--- a/src/main/groovy/org/elasticsearch/groovy/client/AbstractClientExtensions.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/client/AbstractClientExtensions.groovy
@@ -42,9 +42,9 @@ abstract class AbstractClientExtensions {
     protected static
         <Request extends ActionRequest,
          Response extends ActionResponse,
-         Client extends ElasticsearchClient<Client>> PlainListenableActionFuture<Response> doRequest(Client client,
-                                                                                                     Request request,
-                                                                                                     Closure<Response> requestClosure) {
+         Client extends ElasticsearchClient<Client>> PlainListenableActionFuture<Response> doRequestAsync(Client client,
+                                                                                                          Request request,
+                                                                                                          Closure<Response> requestClosure) {
         PlainListenableActionFuture<Response> responseFuture =
                 new PlainListenableActionFuture<>(request.listenerThreaded(), client.threadPool())
 
@@ -69,15 +69,15 @@ abstract class AbstractClientExtensions {
     protected static
         <Request extends ActionRequest,
          Response extends ActionResponse,
-         Client extends ElasticsearchClient<Client>> PlainListenableActionFuture<Response> doRequest(Client client,
-                                                                                                     Request request,
-                                                                                                     Closure requestConfig,
-                                                                                                     Closure<Response> requestClosure) {
+         Client extends ElasticsearchClient<Client>> PlainListenableActionFuture<Response> doRequestAsync(Client client,
+                                                                                                          Request request,
+                                                                                                          Closure requestConfig,
+                                                                                                          Closure<Response> requestClosure) {
         // configure the request
         if (requestConfig != null) {
             request.with(requestConfig)
         }
 
-        doRequest(client, request, requestClosure)
+        doRequestAsync(client, request, requestClosure)
     }
 }

--- a/src/main/groovy/org/elasticsearch/groovy/client/ClientExtensions.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/client/ClientExtensions.groovy
@@ -72,7 +72,7 @@ import org.elasticsearch.common.settings.Settings
  * <p />
  * This enables support for using {@link Closure}s to configure (and execute) the various action requests. For example:
  * <pre>
- * ListenableActionFuture&lt;IndexResponse&gt; indexResponse = client.index {
+ * ListenableActionFuture&lt;IndexResponse&gt; indexResponse = client.indexAsync {
  *     index "index-name"
  *     type "type-name"
  *     id "id-value"
@@ -148,8 +148,41 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link IndexRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#indexAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<IndexResponse> index(Client self, Closure requestClosure) {
+        indexAsync(self, requestClosure)
+    }
+
+    /**
+     * Index a document associated with a given index and type, then get the future result.
+     * <p/>
+     * The id is optional. If it is not provided, one will be generated automatically.
+     * <pre>
+     * IndexResponse response = client.indexAsync {
+     *   index "my-index"
+     *   type "my-type"
+     *   // optional ID
+     *   id "my-id"
+     *   source {
+     *     user = "kimchy"
+     *     postedDate = new Date()
+     *     nested {
+     *       object {
+     *         field = 123
+     *       }
+     *     }
+     *   }
+     * }.actionGet()
+     * </pre>
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link IndexRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<IndexResponse> indexAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, Requests.indexRequest(), requestClosure, self.&index)
     }
 
@@ -204,8 +237,66 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link BulkRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#bulkAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<BulkResponse> bulk(Client self, Closure requestClosure) {
+        bulkAsync(self, requestClosure)
+    }
+
+    /**
+     * Executes a bulk of index, update, or delete operations.
+     * <p />
+     * An example usage of the Bulk API would be to bulk index your own data, which may make sense to wrap for your own
+     * convenience:
+     * <pre>
+     * BulkResponse bulkIndex(String indexName,
+     *                        String typeName,
+     *                        List&lt;Closure&gt; sources) {
+     *     client.bulkAsync {
+     *         // Note: This creates a List&lt;IndexRequest&gt;
+     *         add sources.collect {
+     *             Requests.indexRequest(indexName).type(typeName).source(it)
+     *         }
+     *     }.actionGet()
+     * }
+     * </pre>
+     * Such a method could then be used to build {@code List}s of {@code Closure}s to more clearly bulk index.
+     * <pre>
+     * // Index three documents
+     * BulkResponse response = bulkIndex("my-index", "my-type", [
+     *     { user = "kimchy" },
+     *     { user = "pickypg" },
+     *     { user = "dadoonet" }
+     * ])
+     * </pre>
+     * You could build the {@code List} dynamically in a more realistic example:
+     * <pre>
+     * Closure convertMyObject(MyObject value) {
+     *     // return is used explicitly so that the compiler knows this is
+     *     //  not an arbitrary code block
+     *     return {
+     *         user = value.username
+     *     }
+     * }
+     *
+     * void indexDocuments(List&lt;MyObject&gt; objects) {
+     *     // objects.collect(this.&convertMyObject) returns a List with each item the 1:1 result of calling
+     *     //   convertMyObject(objects[i])
+     *     bulkIndex("my-index", "my-type", objects.collect(this.&convertMyObject))
+     * }
+     * </pre>
+     * If you wanted to mix-and-match indexing, updating, and deletions, then this approach would have to be modified,
+     * but for the common use case of only adding new documents, then this should simplify a lot of bulk insertions. If
+     * you wanted to mix-and-match different indices or types, then a variation of this could be created using the
+     * Groovy-supplied {@code with} method at the expense of complicating each {@code Closure}.
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link BulkRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<BulkResponse> bulkAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new BulkRequest(), requestClosure, self.&bulk)
     }
 
@@ -250,8 +341,56 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link UpdateRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#updateAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<UpdateResponse> update(Client self, Closure requestClosure) {
+        updateAsync(self, requestClosure)
+    }
+
+    /**
+     * Updates a document based on a script or given source.
+     * <p />
+     * For an unscripted example, you could simply replace fields (all or partially) in an existing document:
+     * <pre>
+     * UpdateResponse response = client.updateAsync {
+     *     index "my-index"
+     *     type "my-type"
+     *     id "my-id"
+     *     // Add/replace document fields
+     *     doc {
+     *         new_field = 456.7
+     *     }
+     * }.actionGet()
+     * </pre>
+     * For a scripted example, you might do something like:
+     * <pre>
+     * UpdateResponse response = client.updateAsync {
+     *     index "my-index"
+     *     type "my-type"
+     *     id "my-id"
+     *     script "ctx._source.counter += count"
+     *     scriptParams {
+     *         count = 1
+     *     }
+     *     upsert {
+     *         some {
+     *           other {
+     *               info = "indexed if document does not exist"
+     *           }
+     *         }
+     *         counter = 1
+     *     }
+     * }.actionGet()
+     * </pre>
+     * Note: All updates are really delete-then-index operations and partial updates <em>require</em> that the
+     * document's source be stored (defaults to {@code true}, but changeable in the type's mapping).
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link UpdateRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<UpdateResponse> updateAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new UpdateRequest(), requestClosure, self.&update)
     }
 
@@ -268,8 +407,28 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link DeleteRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#deleteAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<DeleteResponse> delete(Client self, Closure requestClosure) {
+        deleteAsync(self, requestClosure)
+    }
+
+    /**
+     * Deletes a document from the index based on the index, type and id.
+     * <pre>
+     * DeleteResponse response = client.deleteAsync {
+     *     index "my-index"
+     *     type "my-type"
+     *     id "my-id"
+     * }.actionGet()
+     * </pre>
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link DeleteRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<DeleteResponse> deleteAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new DeleteRequest(), requestClosure, self.&delete)
     }
 
@@ -295,8 +454,37 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link DeleteByQueryRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#deleteByQueryAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<DeleteByQueryResponse> deleteByQuery(Client self, Closure requestClosure) {
+        deleteByQueryAsync(self, requestClosure)
+    }
+
+    /**
+     * Deletes all documents from one or more indices based on a query.
+     * <pre>
+     * DeleteByQueryResponse response = client.deleteByQueryAsync {
+     *     indices "my-index"
+     *     types "my-type"
+     *     source {
+     *         query {
+     *             range {
+     *                 // Note: "value" is the field name
+     *                 value {
+     *                     gte = 100
+     *                 }
+     *             }
+     *         }
+     *     }
+     * }.actionGet()
+     * </pre>
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link DeleteByQueryRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<DeleteByQueryResponse> deleteByQueryAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, Requests.deleteByQueryRequest(), requestClosure, self.&deleteByQuery)
     }
 
@@ -315,8 +503,30 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link GetRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#getAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<GetResponse> get(Client self, Closure requestClosure) {
+        getAsync(self, requestClosure)
+    }
+
+    /**
+     * Gets a document from the index based on the index, type and id.
+     * <p />
+     * Note: Get retrievals are performed in real time.
+     * <pre>
+     * GetResponse response = client.getAsync {
+     *     index "my-index"
+     *     type "my-type"
+     *     id "my-id"
+     * }.actionGet()
+     * </pre>
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link GetRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<GetResponse> getAsync(Client self, Closure requestClosure) {
         // index is expected to be set by the closure
         doRequestAsync(self, Requests.getRequest(null), requestClosure, self.&get)
     }
@@ -337,8 +547,31 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link MultiGetRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#multiGetAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<MultiGetResponse> multiGet(Client self, Closure requestClosure) {
+        multiGetAsync(self, requestClosure)
+    }
+
+    /**
+     * Multi-get documents. This provides the mechanism to perform bulk requests (as opposed to bulk indexing) to avoid
+     * unnecessary back-and-forth requests.
+     * <pre>
+     * MultiGetResponse response = client.multiGetAsync {
+     *     // You can still do code constructs in your Closures, like
+     *     //  this loop to invoke add multiple times
+     *     for (String id : ["my-id1", "my-id2", "my-id3"]) {
+     *         add "my-index", "my-type", id
+     *     }
+     * }.actionGet()
+     * </pre>
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link MultiGetRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<MultiGetResponse> multiGetAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new MultiGetRequest(), requestClosure, self.&multiGet)
     }
 
@@ -348,8 +581,21 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link SuggestRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#suggestAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<SuggestResponse> suggest(Client self, Closure requestClosure) {
+        suggestAsync(self, requestClosure)
+    }
+
+    /**
+     * Request suggestion matching for a specific query.
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link SuggestRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<SuggestResponse> suggestAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new SuggestRequest(), requestClosure, self.&suggest)
     }
 
@@ -370,8 +616,32 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link SearchRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#searchAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<SearchResponse> search(Client self, Closure requestClosure) {
+        searchAsync(self, requestClosure)
+    }
+
+    /**
+     * Search across one or more indices and one or more types with a query.
+     * <pre>
+     * SearchResponse response = client.searchAsync {
+     *     indices "my-index1", "my-index2"
+     *     types "my-types1", "my-types2"
+     *     source {
+     *         query {
+     *             match_all { }
+     *         }
+     *     }
+     * }.actionGet()
+     * </pre>
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link SearchRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<SearchResponse> searchAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, Requests.searchRequest(), requestClosure, self.&search)
     }
 
@@ -381,8 +651,21 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link MultiSearchRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#multiSearchAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<MultiSearchResponse> multiSearch(Client self, Closure requestClosure) {
+        multiSearchAsync(self, requestClosure)
+    }
+
+    /**
+     * Perform multiple search requests similar to multi-get.
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link MultiSearchRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<MultiSearchResponse> multiSearchAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new MultiSearchRequest(), requestClosure, self.&multiSearch)
     }
 
@@ -403,8 +686,32 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link CountRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#countAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<CountResponse> count(Client self, Closure requestClosure) {
+        countAsync(self, requestClosure)
+    }
+
+    /**
+     * Request a count of documents matching a specified query.
+     * <pre>
+     * CountResponse response = client.countAsync {
+     *     indices "my-index1", "my-index2"
+     *     types "my-types1", "my-types2"
+     *     source {
+     *         query {
+     *             match_all { }
+     *         }
+     *     }
+     * }.actionGet()
+     * </pre>
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link CountRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<CountResponse> countAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, Requests.countRequest(), requestClosure, self.&count)
     }
 
@@ -441,8 +748,48 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link SearchScrollRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#searchScrollAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<SearchResponse> searchScroll(Client self, Closure requestClosure) {
+        searchScrollAsync(self, requestClosure)
+    }
+
+    /**
+     * A search scroll request to continue searching a previous scrollable search request.
+     * <pre>
+     * // Open the scan
+     * SearchResponse searchResponse = client.searchAsync {
+     *     indices "my-index"
+     *     types "my-type"
+     *     source {
+     *         query {
+     *             match_all { }
+     *         }
+     *         // Note: Size is per shard! 5 shards means 5000 documents per response
+     *         size = 1000
+     *     }
+     *     searchType SearchType.SCAN
+     *     // The time that the scroll stays open should be the minimum duration
+     *     //  required
+     *     scroll "10s"
+     * }.actionGet()
+     *
+     * // Scroll through the results (like a database cursor)
+     * SearchResponse response = client.searchScrollAsync {
+     *     // Note: next call should use response.scrollId!
+     *     scrollId searchResponse.scrollId
+     *     // keep the _next_ window open
+     *     scroll "10s"
+     * }.actionGet()
+     * </pre>
+     * Note: Each {@link SearchResponse} will contain a new ID to use for subsequent requests.
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link SearchScrollRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<SearchResponse> searchScrollAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new SearchScrollRequest(), requestClosure, self.&searchScroll)
     }
 
@@ -459,8 +806,28 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link ClearScrollRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#clearScrollAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<ClearScrollResponse> clearScroll(Client self, Closure requestClosure) {
+        clearScrollAsync(self, requestClosure)
+    }
+
+    /**
+     * Clears the search contexts associated with specified Scroll IDs.
+     * <pre>
+     * ClearScrollResponse response = client.clearScrollAsync {
+     *     addScrollId lastScrollId
+     * }.actionGet()
+     * </pre>
+     * Technically, this is not a necessary action following any scan/scroll action, but you should <em>always</em> do
+     * it to optimistically clean up resources.
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link ClearScrollRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<ClearScrollResponse> clearScrollAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new ClearScrollRequest(), requestClosure, self.&clearScroll)
     }
 
@@ -470,8 +837,21 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link TermVectorRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#termVectorAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<TermVectorResponse> termVector(Client self, Closure requestClosure) {
+        termVectorAsync(self, requestClosure)
+    }
+
+    /**
+     * An action that is the term vectors for a specific document.
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link TermVectorRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<TermVectorResponse> termVectorAsync(Client self, Closure requestClosure) {
         // index, type and id are expected to be set by the closure
         doRequestAsync(self, new TermVectorRequest(null, null, null), requestClosure, self.&termVector)
     }
@@ -482,8 +862,21 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link MultiTermVectorsRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#multiTermVectorsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<MultiTermVectorsResponse> multiTermVectors(Client self, Closure requestClosure) {
+        multiTermVectorsAsync(self, requestClosure)
+    }
+
+    /**
+     * Multi-get term vectors.
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link MultiTermVectorsRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<MultiTermVectorsResponse> multiTermVectorsAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new MultiTermVectorsRequest(), requestClosure, self.&multiTermVectors)
     }
 
@@ -493,8 +886,21 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link PercolateRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#percolateAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<PercolateResponse> percolate(Client self, Closure requestClosure) {
+        percolateAsync(self, requestClosure)
+    }
+
+    /**
+     * Percolates a requesting the matching documents.
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link PercolateRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<PercolateResponse> percolateAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new PercolateRequest(), requestClosure, self.&percolate)
     }
 
@@ -504,8 +910,21 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param self The {@code this} reference for the {@link Client}
      * @param requestClosure The map-like closure that configures the {@link MultiPercolateRequest}.
      * @return Never {@code null}.
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#multiPercolateAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<MultiPercolateResponse> multiPercolate(Client self, Closure requestClosure) {
+        multiPercolateAsync(self, requestClosure)
+    }
+
+    /**
+     * Performs multiple percolate requests.
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link MultiPercolateRequest}.
+     * @return Never {@code null}.
+     */
+    static ListenableActionFuture<MultiPercolateResponse> multiPercolateAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new MultiPercolateRequest(), requestClosure, self.&multiPercolate)
     }
 
@@ -516,8 +935,22 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ExplainRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#explainAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<ExplainResponse> explain(Client self, Closure requestClosure) {
+        explainAsync(self, requestClosure)
+    }
+
+    /**
+     * Computes a score explanation for the specified request.
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link ExplainRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<ExplainResponse> explainAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new ExplainRequest(null, null, null), requestClosure, self.&explain)
     }
 
@@ -558,8 +991,52 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link PutIndexedScriptRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#putIndexedScriptAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<PutIndexedScriptResponse> putIndexedScript(Client self, Closure requestClosure) {
+        putIndexedScriptAsync(self, requestClosure)
+    }
+
+    /**
+     * Put (set/add) the indexed script to be used by other requests.
+     * <pre>
+     * PutIndexedScriptResponse response = client.putIndexedScriptAsync {
+     *     id 'my-script-name'
+     *     // NOTE1: This will be the Groovy runtime within Elasticsearch
+     *     //        and not the Groovy client (this)!
+     *     scriptLang 'groovy'
+     *     source {
+     *         // NOTE2: The script is [in this case] Groovy, but it must
+     *         //        be a string that is interpreted on the server
+     *         // NOTE3: "count" is a script parameter that must be filled
+     *         //        in by the associated update request that makes
+     *         //        use of this script
+     *         script = "ctx._source.count += count"
+     *     }
+     * }.actionGet()
+     * </pre>
+     * Once the above script is added, then you could make use of it by using it with an {@link UpdateRequest}.
+     * <pre>
+     * UpdateResponse updateResponse = client.updateAsync {
+     *     index indexName
+     *     type typeName
+     *     id docId
+     *     source {
+     *         script_id 'testPutIndexedScriptRequest'
+     *         lang 'groovy'
+     *         params {
+     *             count = 5
+     *         }
+     *     }
+     * }.actionGet()
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link PutIndexedScriptRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<PutIndexedScriptResponse> putIndexedScriptAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new PutIndexedScriptRequest(), requestClosure, self.&putIndexedScript)
     }
 
@@ -576,8 +1053,28 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetIndexedScriptRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#getIndexedScriptAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<GetIndexedScriptResponse> getIndexedScript(Client self, Closure requestClosure) {
+        getIndexedScriptAsync(self, requestClosure)
+    }
+
+    /**
+     * Get an indexed script.
+     * <pre>
+     * GetIndexedScriptResponse response = client.getIndexedScriptAsync {
+     *     id 'my-script-name'
+     *     scriptLang 'groovy'
+     * }.actionGet()
+     * </pre>
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link GetIndexedScriptRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<GetIndexedScriptResponse> getIndexedScriptAsync(Client self, Closure requestClosure) {
         doRequestAsync(self, new GetIndexedScriptRequest(), requestClosure, self.&getIndexedScript)
     }
 
@@ -594,9 +1091,30 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link DeleteIndexedScriptRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#deleteIndexedScriptAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<DeleteIndexedScriptResponse> deleteIndexedScript(Client self,
                                                                                    Closure requestClosure) {
+        deleteIndexedScriptAsync(self, requestClosure)
+    }
+
+    /**
+     * Delete an indexed script.
+     * <pre>
+     * DeleteIndexedScriptResponse response = client.deleteIndexedScript {
+     *     id 'my-script-name'
+     *     scriptLang 'groovy'
+     * }.actionGet()
+     * </pre>
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param requestClosure The map-like closure that configures the {@link DeleteIndexedScriptRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<DeleteIndexedScriptResponse> deleteIndexedScriptAsync(Client self,
+                                                                                        Closure requestClosure) {
         doRequestAsync(self, new DeleteIndexedScriptRequest(), requestClosure, self.&deleteIndexedScript)
     }
 
@@ -611,8 +1129,26 @@ class ClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link MoreLikeThisRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null} except {@code index}
+     * @deprecated As of 1.5, replaced by {@link ClientExtensions#moreLikeThisAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<SearchResponse> moreLikeThis(Client self, String index, Closure requestClosure) {
+        moreLikeThisAsync(self, index, requestClosure)
+    }
+
+    /**
+     * A more like this action to search for documents that are "like" a specific document.
+     * <p />
+     * This method may be deprecated in favor of one that does not <em>require</em> the {@code index} to be supplied to
+     * the method in the future.
+     *
+     * @param self The {@code this} reference for the {@link Client}
+     * @param index The index to load the document(s) from
+     * @param requestClosure The map-like closure that configures the {@link MoreLikeThisRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null} except {@code index}
+     */
+    static ListenableActionFuture<SearchResponse> moreLikeThisAsync(Client self, String index, Closure requestClosure) {
         // the only one that _requires_ the index as a parameter/constructor arg (no public setter)
         doRequestAsync(self, Requests.moreLikeThisRequest(index), requestClosure, self.&moreLikeThis)
     }

--- a/src/main/groovy/org/elasticsearch/groovy/client/ClientExtensions.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/client/ClientExtensions.groovy
@@ -150,7 +150,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<IndexResponse> index(Client self, Closure requestClosure) {
-        doRequest(self, Requests.indexRequest(), requestClosure, self.&index)
+        doRequestAsync(self, Requests.indexRequest(), requestClosure, self.&index)
     }
 
     /**
@@ -206,7 +206,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<BulkResponse> bulk(Client self, Closure requestClosure) {
-        doRequest(self, new BulkRequest(), requestClosure, self.&bulk)
+        doRequestAsync(self, new BulkRequest(), requestClosure, self.&bulk)
     }
 
     /**
@@ -252,7 +252,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @return Never {@code null}.
      */
     static ListenableActionFuture<UpdateResponse> update(Client self, Closure requestClosure) {
-        doRequest(self, new UpdateRequest(), requestClosure, self.&update)
+        doRequestAsync(self, new UpdateRequest(), requestClosure, self.&update)
     }
 
     /**
@@ -270,7 +270,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @return Never {@code null}.
      */
     static ListenableActionFuture<DeleteResponse> delete(Client self, Closure requestClosure) {
-        doRequest(self, new DeleteRequest(), requestClosure, self.&delete)
+        doRequestAsync(self, new DeleteRequest(), requestClosure, self.&delete)
     }
 
     /**
@@ -297,7 +297,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @return Never {@code null}.
      */
     static ListenableActionFuture<DeleteByQueryResponse> deleteByQuery(Client self, Closure requestClosure) {
-        doRequest(self, Requests.deleteByQueryRequest(), requestClosure, self.&deleteByQuery)
+        doRequestAsync(self, Requests.deleteByQueryRequest(), requestClosure, self.&deleteByQuery)
     }
 
     /**
@@ -318,7 +318,7 @@ class ClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<GetResponse> get(Client self, Closure requestClosure) {
         // index is expected to be set by the closure
-        doRequest(self, Requests.getRequest(null), requestClosure, self.&get)
+        doRequestAsync(self, Requests.getRequest(null), requestClosure, self.&get)
     }
 
     /**
@@ -339,7 +339,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @return Never {@code null}.
      */
     static ListenableActionFuture<MultiGetResponse> multiGet(Client self, Closure requestClosure) {
-        doRequest(self, new MultiGetRequest(), requestClosure, self.&multiGet)
+        doRequestAsync(self, new MultiGetRequest(), requestClosure, self.&multiGet)
     }
 
     /**
@@ -350,7 +350,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @return Never {@code null}.
      */
     static ListenableActionFuture<SuggestResponse> suggest(Client self, Closure requestClosure) {
-        doRequest(self, new SuggestRequest(), requestClosure, self.&suggest)
+        doRequestAsync(self, new SuggestRequest(), requestClosure, self.&suggest)
     }
 
     /**
@@ -372,7 +372,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @return Never {@code null}.
      */
     static ListenableActionFuture<SearchResponse> search(Client self, Closure requestClosure) {
-        doRequest(self, Requests.searchRequest(), requestClosure, self.&search)
+        doRequestAsync(self, Requests.searchRequest(), requestClosure, self.&search)
     }
 
     /**
@@ -383,7 +383,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @return Never {@code null}.
      */
     static ListenableActionFuture<MultiSearchResponse> multiSearch(Client self, Closure requestClosure) {
-        doRequest(self, new MultiSearchRequest(), requestClosure, self.&multiSearch)
+        doRequestAsync(self, new MultiSearchRequest(), requestClosure, self.&multiSearch)
     }
 
     /**
@@ -405,7 +405,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @return Never {@code null}.
      */
     static ListenableActionFuture<CountResponse> count(Client self, Closure requestClosure) {
-        doRequest(self, Requests.countRequest(), requestClosure, self.&count)
+        doRequestAsync(self, Requests.countRequest(), requestClosure, self.&count)
     }
 
     /**
@@ -443,7 +443,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @return Never {@code null}.
      */
     static ListenableActionFuture<SearchResponse> searchScroll(Client self, Closure requestClosure) {
-        doRequest(self, new SearchScrollRequest(), requestClosure, self.&searchScroll)
+        doRequestAsync(self, new SearchScrollRequest(), requestClosure, self.&searchScroll)
     }
 
     /**
@@ -461,7 +461,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @return Never {@code null}.
      */
     static ListenableActionFuture<ClearScrollResponse> clearScroll(Client self, Closure requestClosure) {
-        doRequest(self, new ClearScrollRequest(), requestClosure, self.&clearScroll)
+        doRequestAsync(self, new ClearScrollRequest(), requestClosure, self.&clearScroll)
     }
 
     /**
@@ -473,7 +473,7 @@ class ClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<TermVectorResponse> termVector(Client self, Closure requestClosure) {
         // index, type and id are expected to be set by the closure
-        doRequest(self, new TermVectorRequest(null, null, null), requestClosure, self.&termVector)
+        doRequestAsync(self, new TermVectorRequest(null, null, null), requestClosure, self.&termVector)
     }
 
     /**
@@ -484,7 +484,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @return Never {@code null}.
      */
     static ListenableActionFuture<MultiTermVectorsResponse> multiTermVectors(Client self, Closure requestClosure) {
-        doRequest(self, new MultiTermVectorsRequest(), requestClosure, self.&multiTermVectors)
+        doRequestAsync(self, new MultiTermVectorsRequest(), requestClosure, self.&multiTermVectors)
     }
 
     /**
@@ -495,7 +495,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @return Never {@code null}.
      */
     static ListenableActionFuture<PercolateResponse> percolate(Client self, Closure requestClosure) {
-        doRequest(self, new PercolateRequest(), requestClosure, self.&percolate)
+        doRequestAsync(self, new PercolateRequest(), requestClosure, self.&percolate)
     }
 
     /**
@@ -506,7 +506,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @return Never {@code null}.
      */
     static ListenableActionFuture<MultiPercolateResponse> multiPercolate(Client self, Closure requestClosure) {
-        doRequest(self, new MultiPercolateRequest(), requestClosure, self.&multiPercolate)
+        doRequestAsync(self, new MultiPercolateRequest(), requestClosure, self.&multiPercolate)
     }
 
     /**
@@ -518,7 +518,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<ExplainResponse> explain(Client self, Closure requestClosure) {
-        doRequest(self, new ExplainRequest(null, null, null), requestClosure, self.&explain)
+        doRequestAsync(self, new ExplainRequest(null, null, null), requestClosure, self.&explain)
     }
 
     /**
@@ -560,7 +560,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<PutIndexedScriptResponse> putIndexedScript(Client self, Closure requestClosure) {
-        doRequest(self, new PutIndexedScriptRequest(), requestClosure, self.&putIndexedScript)
+        doRequestAsync(self, new PutIndexedScriptRequest(), requestClosure, self.&putIndexedScript)
     }
 
     /**
@@ -578,7 +578,7 @@ class ClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<GetIndexedScriptResponse> getIndexedScript(Client self, Closure requestClosure) {
-        doRequest(self, new GetIndexedScriptRequest(), requestClosure, self.&getIndexedScript)
+        doRequestAsync(self, new GetIndexedScriptRequest(), requestClosure, self.&getIndexedScript)
     }
 
     /**
@@ -597,7 +597,7 @@ class ClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<DeleteIndexedScriptResponse> deleteIndexedScript(Client self,
                                                                                    Closure requestClosure) {
-        doRequest(self, new DeleteIndexedScriptRequest(), requestClosure, self.&deleteIndexedScript)
+        doRequestAsync(self, new DeleteIndexedScriptRequest(), requestClosure, self.&deleteIndexedScript)
     }
 
     /**
@@ -614,6 +614,6 @@ class ClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<SearchResponse> moreLikeThis(Client self, String index, Closure requestClosure) {
         // the only one that _requires_ the index as a parameter/constructor arg (no public setter)
-        doRequest(self, Requests.moreLikeThisRequest(index), requestClosure, self.&moreLikeThis)
+        doRequestAsync(self, Requests.moreLikeThisRequest(index), requestClosure, self.&moreLikeThis)
     }
 }

--- a/src/main/groovy/org/elasticsearch/groovy/client/ClusterAdminClientExtensions.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/client/ClusterAdminClientExtensions.groovy
@@ -80,7 +80,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<ClusterHealthResponse> health(ClusterAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.clusterHealthRequest(), requestClosure, self.&health)
+        doRequestAsync(self, Requests.clusterHealthRequest(), requestClosure, self.&health)
     }
 
     /**
@@ -92,7 +92,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<ClusterStateResponse> state(ClusterAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.clusterStateRequest(), requestClosure, self.&state)
+        doRequestAsync(self, Requests.clusterStateRequest(), requestClosure, self.&state)
     }
 
     /**
@@ -105,7 +105,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<ClusterUpdateSettingsResponse> updateSettings(ClusterAdminClient self,
                                                                                 Closure requestClosure) {
-        doRequest(self, Requests.clusterUpdateSettingsRequest(), requestClosure, self.&updateSettings)
+        doRequestAsync(self, Requests.clusterUpdateSettingsRequest(), requestClosure, self.&updateSettings)
     }
 
     /**
@@ -119,7 +119,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<ClusterRerouteResponse> reroute(ClusterAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.clusterRerouteRequest(), requestClosure, self.&reroute)
+        doRequestAsync(self, Requests.clusterRerouteRequest(), requestClosure, self.&reroute)
     }
 
     /**
@@ -131,7 +131,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<ClusterStatsResponse> clusterStats(ClusterAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.clusterStatsRequest(), requestClosure, self.&clusterStats)
+        doRequestAsync(self, Requests.clusterStatsRequest(), requestClosure, self.&clusterStats)
     }
 
     /**
@@ -143,7 +143,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<NodesInfoResponse> nodesInfo(ClusterAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.nodesInfoRequest(), requestClosure, self.&nodesInfo)
+        doRequestAsync(self, Requests.nodesInfoRequest(), requestClosure, self.&nodesInfo)
     }
 
     /**
@@ -155,7 +155,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<NodesStatsResponse> nodesStats(ClusterAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.nodesStatsRequest(), requestClosure, self.&nodesStats)
+        doRequestAsync(self, Requests.nodesStatsRequest(), requestClosure, self.&nodesStats)
     }
 
     /**
@@ -168,7 +168,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<NodesHotThreadsResponse> nodesHotThreads(ClusterAdminClient self,
                                                                            Closure requestClosure) {
-        doRequest(self, new NodesHotThreadsRequest(), requestClosure, self.&nodesHotThreads)
+        doRequestAsync(self, new NodesHotThreadsRequest(), requestClosure, self.&nodesHotThreads)
     }
 
     /**
@@ -180,7 +180,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<NodesRestartResponse> nodesRestart(ClusterAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.nodesRestartRequest(), requestClosure, self.&nodesRestart)
+        doRequestAsync(self, Requests.nodesRestartRequest(), requestClosure, self.&nodesRestart)
     }
 
     /**
@@ -193,7 +193,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<NodesShutdownResponse> nodesShutdown(ClusterAdminClient self,
                                                                        Closure requestClosure) {
-        doRequest(self, Requests.nodesShutdownRequest(), requestClosure, self.&nodesShutdown)
+        doRequestAsync(self, Requests.nodesShutdownRequest(), requestClosure, self.&nodesShutdown)
     }
 
     /**
@@ -206,7 +206,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<ClusterSearchShardsResponse> searchShards(ClusterAdminClient self,
                                                                             Closure requestClosure) {
-        doRequest(self, Requests.clusterSearchShardsRequest(), requestClosure, self.&searchShards)
+        doRequestAsync(self, Requests.clusterSearchShardsRequest(), requestClosure, self.&searchShards)
     }
 
     /**
@@ -220,7 +220,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
     static ListenableActionFuture<PutRepositoryResponse> putRepository(ClusterAdminClient self,
                                                                        Closure requestClosure) {
         // closure is expected to set the repo name
-        doRequest(self, Requests.putRepositoryRequest(null), requestClosure, self.&putRepository)
+        doRequestAsync(self, Requests.putRepositoryRequest(null), requestClosure, self.&putRepository)
     }
 
     /**
@@ -234,7 +234,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
     static ListenableActionFuture<DeleteRepositoryResponse> deleteRepository(ClusterAdminClient self,
                                                                              Closure requestClosure) {
         // closure is expected to set the repo name
-        doRequest(self, Requests.deleteRepositoryRequest(null), requestClosure, self.&deleteRepository)
+        doRequestAsync(self, Requests.deleteRepositoryRequest(null), requestClosure, self.&deleteRepository)
     }
 
     /**
@@ -247,7 +247,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<GetRepositoriesResponse> getRepositories(ClusterAdminClient self,
                                                                            Closure requestClosure) {
-        doRequest(self, Requests.getRepositoryRequest(), requestClosure, self.&getRepositories)
+        doRequestAsync(self, Requests.getRepositoryRequest(), requestClosure, self.&getRepositories)
     }
 
     /**
@@ -261,7 +261,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
     static ListenableActionFuture<CreateSnapshotResponse> createSnapshot(ClusterAdminClient self,
                                                                          Closure requestClosure) {
         // closure is expected to set the repo and snapshot names
-        doRequest(self, Requests.createSnapshotRequest(null, null), requestClosure, self.&createSnapshot)
+        doRequestAsync(self, Requests.createSnapshotRequest(null, null), requestClosure, self.&createSnapshot)
     }
 
     /**
@@ -275,7 +275,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
     static ListenableActionFuture<SnapshotsStatusResponse> snapshotsStatus(ClusterAdminClient self,
                                                                            Closure requestClosure) {
         // closure is expected to set the repo name
-        doRequest(self, Requests.snapshotsStatusRequest(null), requestClosure, self.&snapshotsStatus)
+        doRequestAsync(self, Requests.snapshotsStatusRequest(null), requestClosure, self.&snapshotsStatus)
     }
 
     /**
@@ -288,7 +288,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<GetSnapshotsResponse> getSnapshots(ClusterAdminClient self, Closure requestClosure) {
         // closure is expected to set the repo name
-        doRequest(self, Requests.getSnapshotsRequest(null), requestClosure, self.&getSnapshots)
+        doRequestAsync(self, Requests.getSnapshotsRequest(null), requestClosure, self.&getSnapshots)
     }
 
     /**
@@ -302,7 +302,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
     static ListenableActionFuture<RestoreSnapshotResponse> restoreSnapshot(ClusterAdminClient self,
                                                                            Closure requestClosure) {
         // closure is expected to set the repo and snapshot names
-        doRequest(self, Requests.restoreSnapshotRequest(null, null), requestClosure, self.&restoreSnapshot)
+        doRequestAsync(self, Requests.restoreSnapshotRequest(null, null), requestClosure, self.&restoreSnapshot)
     }
 
     /**
@@ -319,7 +319,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
     static ListenableActionFuture<DeleteSnapshotResponse> deleteSnapshot(ClusterAdminClient self,
                                                                          Closure requestClosure) {
         // closure is expected to set the repo and snapshot names
-        doRequest(self, Requests.deleteSnapshotRequest(null, null), requestClosure, self.&deleteSnapshot)
+        doRequestAsync(self, Requests.deleteSnapshotRequest(null, null), requestClosure, self.&deleteSnapshot)
     }
 
     /**
@@ -334,6 +334,6 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<PendingClusterTasksResponse> pendingClusterTasks(ClusterAdminClient self,
                                                                                    Closure requestClosure) {
-        doRequest(self, new PendingClusterTasksRequest(), requestClosure, self.&pendingClusterTasks)
+        doRequestAsync(self, new PendingClusterTasksRequest(), requestClosure, self.&pendingClusterTasks)
     }
 }

--- a/src/main/groovy/org/elasticsearch/groovy/client/ClusterAdminClientExtensions.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/client/ClusterAdminClientExtensions.groovy
@@ -78,8 +78,22 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClusterHealthRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#healthAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<ClusterHealthResponse> health(ClusterAdminClient self, Closure requestClosure) {
+        healthAsync(self, requestClosure)
+    }
+
+    /**
+     * Get the health of the cluster.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link ClusterHealthRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<ClusterHealthResponse> healthAsync(ClusterAdminClient self, Closure requestClosure) {
         doRequestAsync(self, Requests.clusterHealthRequest(), requestClosure, self.&health)
     }
 
@@ -90,8 +104,22 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClusterStateRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#stateAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<ClusterStateResponse> state(ClusterAdminClient self, Closure requestClosure) {
+        stateAsync(self, requestClosure)
+    }
+
+    /**
+     * Get the state of the cluster.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link ClusterStateRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<ClusterStateResponse> stateAsync(ClusterAdminClient self, Closure requestClosure) {
         doRequestAsync(self, Requests.clusterStateRequest(), requestClosure, self.&state)
     }
 
@@ -102,8 +130,23 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClusterUpdateSettingsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#updateSettingsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<ClusterUpdateSettingsResponse> updateSettings(ClusterAdminClient self,
+                                                                                Closure requestClosure) {
+        updateSettingsAsync(self, requestClosure)
+    }
+
+    /**
+     * Update settings in the cluster.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link ClusterUpdateSettingsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<ClusterUpdateSettingsResponse> updateSettingsAsync(ClusterAdminClient self,
                                                                                 Closure requestClosure) {
         doRequestAsync(self, Requests.clusterUpdateSettingsRequest(), requestClosure, self.&updateSettings)
     }
@@ -117,8 +160,25 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClusterRerouteRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#rerouteAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<ClusterRerouteResponse> reroute(ClusterAdminClient self, Closure requestClosure) {
+        rerouteAsync(self, requestClosure)
+    }
+
+    /**
+     * Reroute the allocation of shards in the cluster.
+     * <p />
+     * Note: This is an Advanced API and care should be taken before performing related operations.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link ClusterRerouteRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<ClusterRerouteResponse> rerouteAsync(ClusterAdminClient self,
+                                                                       Closure requestClosure) {
         doRequestAsync(self, Requests.clusterRerouteRequest(), requestClosure, self.&reroute)
     }
 
@@ -129,8 +189,23 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClusterStatsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#clusterStatsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<ClusterStatsResponse> clusterStats(ClusterAdminClient self, Closure requestClosure) {
+        clusterStatsAsync(self, requestClosure)
+    }
+
+    /**
+     * Get the cluster-wide aggregated stats.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link ClusterStatsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<ClusterStatsResponse> clusterStatsAsync(ClusterAdminClient self,
+                                                                          Closure requestClosure) {
         doRequestAsync(self, Requests.clusterStatsRequest(), requestClosure, self.&clusterStats)
     }
 
@@ -141,8 +216,22 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link NodesInfoRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#nodeInfoAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<NodesInfoResponse> nodesInfo(ClusterAdminClient self, Closure requestClosure) {
+        nodesInfoAsync(self, requestClosure)
+    }
+
+    /**
+     * Get the nodes info of the cluster.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link NodesInfoRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<NodesInfoResponse> nodesInfoAsync(ClusterAdminClient self, Closure requestClosure) {
         doRequestAsync(self, Requests.nodesInfoRequest(), requestClosure, self.&nodesInfo)
     }
 
@@ -153,8 +242,22 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link NodesStatsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#nodeStatsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<NodesStatsResponse> nodesStats(ClusterAdminClient self, Closure requestClosure) {
+        nodesStatsAsync(self, requestClosure)
+    }
+
+    /**
+     * Get the nodes stats of the cluster.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link NodesStatsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<NodesStatsResponse> nodesStatsAsync(ClusterAdminClient self, Closure requestClosure) {
         doRequestAsync(self, Requests.nodesStatsRequest(), requestClosure, self.&nodesStats)
     }
 
@@ -165,9 +268,24 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link NodesHotThreadsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#nodesHotThreadsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<NodesHotThreadsResponse> nodesHotThreads(ClusterAdminClient self,
                                                                            Closure requestClosure) {
+        nodesHotThreadsAsync(self, requestClosure)
+    }
+
+    /**
+     * Get the hot threads details from nodes in the cluster.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link NodesHotThreadsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<NodesHotThreadsResponse> nodesHotThreadsAsync(ClusterAdminClient self,
+                                                                                Closure requestClosure) {
         doRequestAsync(self, new NodesHotThreadsRequest(), requestClosure, self.&nodesHotThreads)
     }
 
@@ -178,8 +296,23 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link NodesRestartRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#nodesRestartAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<NodesRestartResponse> nodesRestart(ClusterAdminClient self, Closure requestClosure) {
+        nodesRestartAsync(self, requestClosure)
+    }
+
+    /**
+     * Restart nodes in the cluster.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link NodesRestartRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<NodesRestartResponse> nodesRestartAsync(ClusterAdminClient self,
+                                                                          Closure requestClosure) {
         doRequestAsync(self, Requests.nodesRestartRequest(), requestClosure, self.&nodesRestart)
     }
 
@@ -190,9 +323,24 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link NodesShutdownRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#nodesShutdownAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<NodesShutdownResponse> nodesShutdown(ClusterAdminClient self,
                                                                        Closure requestClosure) {
+        nodesShutdownAsync(self, requestClosure)
+    }
+
+    /**
+     * Shutdown nodes in the cluster.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link NodesShutdownRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<NodesShutdownResponse> nodesShutdownAsync(ClusterAdminClient self,
+                                                                            Closure requestClosure) {
         doRequestAsync(self, Requests.nodesShutdownRequest(), requestClosure, self.&nodesShutdown)
     }
 
@@ -203,9 +351,24 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClusterSearchShardsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#searchShardsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<ClusterSearchShardsResponse> searchShards(ClusterAdminClient self,
                                                                             Closure requestClosure) {
+        searchShardsAsync(self, requestClosure)
+    }
+
+    /**
+     * Determine the shards that the given search would be executed on within the cluster.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link ClusterSearchShardsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<ClusterSearchShardsResponse> searchShardsAsync(ClusterAdminClient self,
+                                                                                 Closure requestClosure) {
         doRequestAsync(self, Requests.clusterSearchShardsRequest(), requestClosure, self.&searchShards)
     }
 
@@ -216,9 +379,24 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link PutRepositoryRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#putSnapshotAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<PutRepositoryResponse> putRepository(ClusterAdminClient self,
                                                                        Closure requestClosure) {
+        putRepositoryAsync(self, requestClosure)
+    }
+
+    /**
+     * Register a snapshot repository.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link PutRepositoryRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<PutRepositoryResponse> putRepositoryAsync(ClusterAdminClient self,
+                                                                            Closure requestClosure) {
         // closure is expected to set the repo name
         doRequestAsync(self, Requests.putRepositoryRequest(null), requestClosure, self.&putRepository)
     }
@@ -230,9 +408,24 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link DeleteRepositoryRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#deleteRepositoryAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<DeleteRepositoryResponse> deleteRepository(ClusterAdminClient self,
                                                                              Closure requestClosure) {
+        deleteRepositoryAsync(self, requestClosure)
+    }
+
+    /**
+     * Unregister a snapshot repository.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link DeleteRepositoryRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<DeleteRepositoryResponse> deleteRepositoryAsync(ClusterAdminClient self,
+                                                                                  Closure requestClosure) {
         // closure is expected to set the repo name
         doRequestAsync(self, Requests.deleteRepositoryRequest(null), requestClosure, self.&deleteRepository)
     }
@@ -244,9 +437,24 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetRepositoriesRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#getRepositoriesAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<GetRepositoriesResponse> getRepositories(ClusterAdminClient self,
                                                                            Closure requestClosure) {
+        getRepositoriesAsync(self, requestClosure)
+    }
+
+    /**
+     * Get snapshot repositories.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link GetRepositoriesRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<GetRepositoriesResponse> getRepositoriesAsync(ClusterAdminClient self,
+                                                                                Closure requestClosure) {
         doRequestAsync(self, Requests.getRepositoryRequest(), requestClosure, self.&getRepositories)
     }
 
@@ -257,9 +465,24 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link CreateSnapshotRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#createSnapshotAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<CreateSnapshotResponse> createSnapshot(ClusterAdminClient self,
                                                                          Closure requestClosure) {
+        createSnapshotAsync(self, requestClosure)
+    }
+
+    /**
+     * Create a new snapshot in a repository.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link CreateSnapshotRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<CreateSnapshotResponse> createSnapshotAsync(ClusterAdminClient self,
+                                                                              Closure requestClosure) {
         // closure is expected to set the repo and snapshot names
         doRequestAsync(self, Requests.createSnapshotRequest(null, null), requestClosure, self.&createSnapshot)
     }
@@ -271,9 +494,24 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link SnapshotsStatusRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#snapshotsStatusAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<SnapshotsStatusResponse> snapshotsStatus(ClusterAdminClient self,
                                                                            Closure requestClosure) {
+        snapshotsStatusAsync(self, requestClosure)
+    }
+
+    /**
+     * Get the snapshots status from a repository.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link SnapshotsStatusRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<SnapshotsStatusResponse> snapshotsStatusAsync(ClusterAdminClient self,
+                                                                                Closure requestClosure) {
         // closure is expected to set the repo name
         doRequestAsync(self, Requests.snapshotsStatusRequest(null), requestClosure, self.&snapshotsStatus)
     }
@@ -285,8 +523,23 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetSnapshotsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#getSnapshotsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<GetSnapshotsResponse> getSnapshots(ClusterAdminClient self, Closure requestClosure) {
+        getSnapshotsAsync(self, requestClosure)
+    }
+
+    /**
+     * Get snapshots from a repository.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link GetSnapshotsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<GetSnapshotsResponse> getSnapshotsAsync(ClusterAdminClient self,
+                                                                          Closure requestClosure) {
         // closure is expected to set the repo name
         doRequestAsync(self, Requests.getSnapshotsRequest(null), requestClosure, self.&getSnapshots)
     }
@@ -298,8 +551,23 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link RestoreSnapshotRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#restoreSnapshotAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<RestoreSnapshotResponse> restoreSnapshot(ClusterAdminClient self,
+                                                                           Closure requestClosure) {
+        restoreSnapshotAsync(self, requestClosure)
+    }
+
+    /**
+     * Restore from a snapshot in a repository.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link RestoreSnapshotRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<RestoreSnapshotResponse> restoreSnapshotAsync(ClusterAdminClient self,
                                                                            Closure requestClosure) {
         // closure is expected to set the repo and snapshot names
         doRequestAsync(self, Requests.restoreSnapshotRequest(null, null), requestClosure, self.&restoreSnapshot)
@@ -315,9 +583,27 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link DeleteSnapshotRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#deleteSnapshotAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<DeleteSnapshotResponse> deleteSnapshot(ClusterAdminClient self,
                                                                          Closure requestClosure) {
+        deleteSnapshotAsync(self, requestClosure)
+    }
+
+    /**
+     * Delete snapshots from a repository.
+     * <p>
+     * Note: Deleting a snapshot should only be done after creating newer snapshots, which are themselves backed up, in
+     * order to avoid data loss.
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link DeleteSnapshotRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<DeleteSnapshotResponse> deleteSnapshotAsync(ClusterAdminClient self,
+                                                                              Closure requestClosure) {
         // closure is expected to set the repo and snapshot names
         doRequestAsync(self, Requests.deleteSnapshotRequest(null, null), requestClosure, self.&deleteSnapshot)
     }
@@ -331,9 +617,26 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link PendingClusterTasksRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#pendingClusterTasksAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<PendingClusterTasksResponse> pendingClusterTasks(ClusterAdminClient self,
                                                                                    Closure requestClosure) {
+        pendingClusterTasksAsync(self, requestClosure)
+    }
+
+    /**
+     * Get a list of pending cluster tasks that are scheduled to be executed.
+     * <p>
+     * This includes operations that update the cluster state (e.g., a create index operation).
+     *
+     * @param self The {@code this} reference for the {@link ClusterAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link PendingClusterTasksRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<PendingClusterTasksResponse> pendingClusterTasksAsync(ClusterAdminClient self,
+                                                                                        Closure requestClosure) {
         doRequestAsync(self, new PendingClusterTasksRequest(), requestClosure, self.&pendingClusterTasks)
     }
 }

--- a/src/main/groovy/org/elasticsearch/groovy/client/IndicesAdminClientExtensions.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/client/IndicesAdminClientExtensions.groovy
@@ -97,8 +97,22 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link RefreshRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#refreshAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<RefreshResponse> refresh(IndicesAdminClient self, Closure requestClosure) {
+        refreshAsync(self, requestClosure)
+    }
+
+    /**
+     * Explicitly refresh one or more indices, which makes all content indexed since the last refresh searchable.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link RefreshRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<RefreshResponse> refreshAsync(IndicesAdminClient self, Closure requestClosure) {
         doRequestAsync(self, Requests.refreshRequest(), requestClosure, self.&refresh)
     }
 
@@ -109,8 +123,22 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link IndicesExistsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#existsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<IndicesExistsResponse> exists(IndicesAdminClient self, Closure requestClosure) {
+        existsAsync(self, requestClosure)
+    }
+
+    /**
+     * Determine if the specified indices exist.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link IndicesExistsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<IndicesExistsResponse> existsAsync(IndicesAdminClient self, Closure requestClosure) {
         doRequestAsync(self, Requests.indicesExistsRequest(), requestClosure, self.&exists)
     }
 
@@ -121,8 +149,23 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link TypesExistsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#typesExistsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<TypesExistsResponse> typesExists(IndicesAdminClient self, Closure requestClosure) {
+        typesExistsAsync(self, requestClosure)
+    }
+
+    /**
+     * Determine if the specified types exist within the specified indices.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link TypesExistsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<TypesExistsResponse> typesExistsAsync(IndicesAdminClient self,
+                                                                        Closure requestClosure) {
         // indices must be supplied by the closure
         doRequestAsync(self, new TypesExistsRequest(null), requestClosure, self.&typesExists)
     }
@@ -134,8 +177,22 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link IndicesStatsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#statsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<IndicesStatsResponse> stats(IndicesAdminClient self, Closure requestClosure) {
+        statsAsync(self, requestClosure)
+    }
+
+    /**
+     * Get stats for indices.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link IndicesStatsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<IndicesStatsResponse> statsAsync(IndicesAdminClient self, Closure requestClosure) {
         doRequestAsync(self, new IndicesStatsRequest(), requestClosure, self.&stats)
     }
 
@@ -146,8 +203,22 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link RecoveryRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#recoveriesAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<RecoveryResponse> recoveries(IndicesAdminClient self, Closure requestClosure) {
+        recoveriesAsync(self, requestClosure)
+    }
+
+    /**
+     * Get details pertaining to the recovery state of indices and their associated shards.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link RecoveryRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<RecoveryResponse> recoveriesAsync(IndicesAdminClient self, Closure requestClosure) {
         doRequestAsync(self, new RecoveryRequest(), requestClosure, self.&recoveries)
     }
 
@@ -158,8 +229,23 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link IndicesSegmentsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#segmentsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<IndicesSegmentResponse> segments(IndicesAdminClient self, Closure requestClosure) {
+        segmentsAsync(self, requestClosure)
+    }
+
+    /**
+     * Get details pertaining to the segments of indices.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link IndicesSegmentsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<IndicesSegmentResponse> segmentsAsync(IndicesAdminClient self,
+                                                                        Closure requestClosure) {
         doRequestAsync(self, Requests.indicesExistsRequest(), requestClosure, self.&segments)
     }
 
@@ -170,8 +256,22 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link CreateIndexRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#createAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<CreateIndexResponse> create(IndicesAdminClient self, Closure requestClosure) {
+        createAsync(self, requestClosure)
+    }
+
+    /**
+     * Create an index explicitly, which allows the index configuration to be specified.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link CreateIndexRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<CreateIndexResponse> createAsync(IndicesAdminClient self, Closure requestClosure) {
         // index must be set by the closure
         doRequestAsync(self, Requests.createIndexRequest(null), requestClosure, self.&create)
     }
@@ -185,8 +285,24 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link DeleteIndexRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#deleteAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<DeleteIndexResponse> delete(IndicesAdminClient self, Closure requestClosure) {
+        deleteAsync(self, requestClosure)
+    }
+
+    /**
+     * Delete the specified indices.
+     * <p />
+     * Note: Manually supply the reserved index name of "_all" to delete all indices.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link DeleteIndexRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<DeleteIndexResponse> deleteAsync(IndicesAdminClient self, Closure requestClosure) {
         // index must be set by the closure
         doRequestAsync(self, Requests.deleteIndexRequest(null), requestClosure, self.&delete)
     }
@@ -199,8 +315,23 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link CloseIndexRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#closeAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<CloseIndexResponse> close(IndicesAdminClient self, Closure requestClosure) {
+        closeAsync(self, requestClosure)
+    }
+
+    /**
+     * Close the specified indices. Closing an index prevents documents from being added, updated, or removed. This is
+     * a good way to make an index read-only.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link CloseIndexRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<CloseIndexResponse> closeAsync(IndicesAdminClient self, Closure requestClosure) {
         // index must be set by the closure
         doRequestAsync(self, Requests.closeIndexRequest(null), requestClosure, self.&close)
     }
@@ -212,8 +343,22 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link OpenIndexRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#openAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<OpenIndexResponse> open(IndicesAdminClient self, Closure requestClosure) {
+        openAsync(self, requestClosure)
+    }
+
+    /**
+     * Open the specified indices.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link OpenIndexRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<OpenIndexResponse> openAsync(IndicesAdminClient self, Closure requestClosure) {
         // index must be set by the closure
         doRequestAsync(self, Requests.openIndexRequest(null), requestClosure, self.&open)
     }
@@ -228,8 +373,25 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link FlushRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#flushAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<FlushResponse> flush(IndicesAdminClient self, Closure requestClosure) {
+        flushAsync(self, requestClosure)
+    }
+
+    /**
+     * Explicitly flush the specified indices. A successful flush of an index guarantees that items in its transaction
+     * log have been written to disk and starts a new transaction log.
+     * <p />
+     * Note: By default, Elasticsearch will perform flush operations automatically.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link FlushRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<FlushResponse> flushAsync(IndicesAdminClient self, Closure requestClosure) {
         doRequestAsync(self, Requests.flushRequest(), requestClosure, self.&flush)
     }
 
@@ -247,8 +409,29 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link OptimizeRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#optimizeAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<OptimizeResponse> optimize(IndicesAdminClient self, Closure requestClosure) {
+        optimizeAsync(self, requestClosure)
+    }
+
+    /**
+     * Explicitly optimize the specified indices.
+     * <p />
+     * Optimizing an index will reduce the number of segments that the index contains, which will speed up future search
+     * operations. Like other operations, Elasticsearch will automatically optimize indices in the background.
+     * <p />
+     * The optimal number of segments is <tt>1</tt>, but an active index will regularly have more than <tt>1</tt>. A
+     * {@link IndicesAdminClient#close(CloseIndexRequest) closed} index can be safely optimized to <tt>1</tt> segment to
+     * speed up future search operations.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link OptimizeRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<OptimizeResponse> optimizeAsync(IndicesAdminClient self, Closure requestClosure) {
         doRequestAsync(self, Requests.optimizeRequest(), requestClosure, self.&optimize)
     }
 
@@ -259,8 +442,22 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetMappingsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#getMappingsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<GetMappingsResponse> getMappings(IndicesAdminClient self, Closure requestClosure) {
+        getMappingsAsync(self, requestClosure)
+    }
+
+    /**
+     * Get the mappings of one or more types.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link GetMappingsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<GetMappingsResponse> getMappingsAsync(IndicesAdminClient self, Closure requestClosure) {
         doRequestAsync(self, new GetMappingsRequest(), requestClosure, self.&getMappings)
     }
 
@@ -271,9 +468,24 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetFieldMappingsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#getFieldMappingsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<GetFieldMappingsResponse> getFieldMappings(IndicesAdminClient self,
                                                                              Closure requestClosure) {
+        getFieldMappingsAsync(self, requestClosure)
+    }
+
+    /**
+     * Get the mappings of one or more fields.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link GetFieldMappingsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<GetFieldMappingsResponse> getFieldMappingsAsync(IndicesAdminClient self,
+                                                                                  Closure requestClosure) {
         doRequestAsync(self, new GetFieldMappingsRequest(), requestClosure, self.&getFieldMappings)
     }
 
@@ -284,8 +496,22 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link PutMappingRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#putMappingAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<PutMappingResponse> putMapping(IndicesAdminClient self, Closure requestClosure) {
+        putMappingAsync(self, requestClosure)
+    }
+
+    /**
+     * Add the mapping definition for a type into one or more indices.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link PutMappingRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<PutMappingResponse> putMappingAsync(IndicesAdminClient self, Closure requestClosure) {
         doRequestAsync(self, Requests.putMappingRequest(), requestClosure, self.&putMapping)
     }
 
@@ -296,9 +522,24 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link DeleteMappingRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#deleteMappingAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<DeleteMappingResponse> deleteMapping(IndicesAdminClient self,
                                                                        Closure requestClosure) {
+        deleteMappingAsync(self, requestClosure)
+    }
+
+    /**
+     * Delete the mapping definition for a type in one or more indices.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link DeleteMappingRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<DeleteMappingResponse> deleteMappingAsync(IndicesAdminClient self,
+                                                                            Closure requestClosure) {
         doRequestAsync(self, Requests.deleteMappingRequest(), requestClosure, self.&deleteMapping)
     }
 
@@ -309,8 +550,23 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link IndicesAliasesRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#aliasesAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<IndicesAliasesResponse> aliases(IndicesAdminClient self, Closure requestClosure) {
+        aliasesAsync(self, requestClosure)
+    }
+
+    /**
+     * Atomically add or remove index aliases.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link IndicesAliasesRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<IndicesAliasesResponse> aliasesAsync(IndicesAdminClient self,
+                                                                       Closure requestClosure) {
         doRequestAsync(self, Requests.indexAliasesRequest(), requestClosure, self.&aliases)
     }
 
@@ -321,8 +577,22 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetAliasesRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#getAliasesAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<GetAliasesResponse> getAliases(IndicesAdminClient self, Closure requestClosure) {
+        getAliasesAsync(self, requestClosure)
+    }
+
+    /**
+     * Get index aliases.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link GetAliasesRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<GetAliasesResponse> getAliasesAsync(IndicesAdminClient self, Closure requestClosure) {
         doRequestAsync(self, new GetAliasesRequest(), requestClosure, self.&getAliases)
     }
 
@@ -333,8 +603,23 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetAliasesRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#aliasesExistAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<AliasesExistResponse> aliasesExist(IndicesAdminClient self, Closure requestClosure) {
+        aliasesExistAsync(self, requestClosure)
+    }
+
+    /**
+     * Determine if index aliases exist.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link GetAliasesRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<AliasesExistResponse> aliasesExistAsync(IndicesAdminClient self,
+                                                                          Closure requestClosure) {
         doRequestAsync(self, new GetAliasesRequest(), requestClosure, self.&aliasesExist)
     }
 
@@ -345,9 +630,24 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClearIndicesCacheRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#clearCacheAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<ClearIndicesCacheResponse> clearCache(IndicesAdminClient self,
                                                                         Closure requestClosure) {
+        clearCacheAsync(self, requestClosure)
+    }
+
+    /**
+     * Clear the indices specified caches.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link ClearIndicesCacheRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<ClearIndicesCacheResponse> clearCacheAsync(IndicesAdminClient self,
+                                                                             Closure requestClosure) {
         doRequestAsync(self, Requests.clearIndicesCacheRequest(), requestClosure, self.&clearCache)
     }
 
@@ -360,9 +660,26 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link UpdateSettingsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#updateSettingsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<UpdateSettingsResponse> updateSettings(IndicesAdminClient self,
                                                                          Closure requestClosure) {
+        updateSettingsAsync(self, requestClosure)
+    }
+
+    /**
+     * Update the settings of one or more indices.
+     * <p />
+     * Note: Some settings can only be set at the creation of an index, such as the number of shards.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link UpdateSettingsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<UpdateSettingsResponse> updateSettingsAsync(IndicesAdminClient self,
+                                                                              Closure requestClosure) {
         doRequestAsync(self, new UpdateSettingsRequest(), requestClosure, self.&updateSettings)
     }
 
@@ -373,9 +690,24 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link PutIndexTemplateRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#putTemplateAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<PutIndexTemplateResponse> putTemplate(IndicesAdminClient self,
                                                                         Closure requestClosure) {
+        putTemplateAsync(self, requestClosure)
+    }
+
+    /**
+     * Add an index template to enable automatic type mappings.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link PutIndexTemplateRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<PutIndexTemplateResponse> putTemplateAsync(IndicesAdminClient self,
+                                                                             Closure requestClosure) {
         // template name expected be supplied by the closure
         doRequestAsync(self, new PutIndexTemplateRequest(null), requestClosure, self.&putTemplate)
     }
@@ -389,8 +721,25 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param name The name of the index template to delete.
      * @return Never {@code null}.
      * @throws NullPointerException if {@code self} is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#deleteTemplateAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<DeleteIndexTemplateResponse> deleteTemplate(IndicesAdminClient self, String name) {
+        deleteTemplateAsync(self, name)
+    }
+
+    /**
+     * Delete an index template.
+     * <p />
+     * Note: This will <em>not</em> unmap indices that have made use of this template.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param name The name of the index template to delete.
+     * @return Never {@code null}.
+     * @throws NullPointerException if {@code self} is {@code null}
+     */
+    static ListenableActionFuture<DeleteIndexTemplateResponse> deleteTemplateAsync(IndicesAdminClient self,
+                                                                                   String name) {
         doRequestAsync(self, new DeleteIndexTemplateRequest(name), self.&deleteTemplate)
     }
 
@@ -401,9 +750,24 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetIndexTemplatesRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#getTemplatesAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<GetIndexTemplatesResponse> getTemplates(IndicesAdminClient self,
                                                                           Closure requestClosure) {
+        getTemplatesAsync(self, requestClosure)
+    }
+
+    /**
+     * Get index templates.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link GetIndexTemplatesRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<GetIndexTemplatesResponse> getTemplatesAsync(IndicesAdminClient self,
+                                                                               Closure requestClosure) {
         doRequestAsync(self, new GetIndexTemplatesRequest(), requestClosure, self.&getTemplates)
     }
 
@@ -414,9 +778,24 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ValidateQueryRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#validateQueryAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<ValidateQueryResponse> validateQuery(IndicesAdminClient self,
                                                                        Closure requestClosure) {
+        validateQueryAsync(self, requestClosure)
+    }
+
+    /**
+     * Validate a query for correctness.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link ValidateQueryRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<ValidateQueryResponse> validateQueryAsync(IndicesAdminClient self,
+                                                                            Closure requestClosure) {
         doRequestAsync(self, new ValidateQueryRequest(), requestClosure, self.&validateQuery)
     }
 
@@ -427,8 +806,22 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link PutWarmerRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#putWarmerAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<PutWarmerResponse> putWarmer(IndicesAdminClient self, Closure requestClosure) {
+        putWarmerAsync(self, requestClosure)
+    }
+
+    /**
+     * Put an index search warmer.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link PutWarmerRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<PutWarmerResponse> putWarmerAsync(IndicesAdminClient self, Closure requestClosure) {
         // warmer name is expected to be set by the closure
         doRequestAsync(self, new PutWarmerRequest(null), requestClosure, self.&putWarmer)
     }
@@ -440,8 +833,23 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link DeleteWarmerRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#deleteWarmerAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<DeleteWarmerResponse> deleteWarmer(IndicesAdminClient self, Closure requestClosure) {
+        deleteWarmerAsync(self, requestClosure)
+    }
+
+    /**
+     * Delete one or more index search warmers.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link DeleteWarmerRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<DeleteWarmerResponse> deleteWarmerAsync(IndicesAdminClient self,
+                                                                          Closure requestClosure) {
         doRequestAsync(self, new DeleteWarmerRequest(), requestClosure, self.&deleteWarmer)
     }
 
@@ -452,8 +860,22 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetWarmersRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#getWarmersAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<GetWarmersResponse> getWarmers(IndicesAdminClient self, Closure requestClosure) {
+        getWarmersAsync(self, requestClosure)
+    }
+
+    /**
+     * Get index search warmers.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link GetWarmersRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<GetWarmersResponse> getWarmersAsync(IndicesAdminClient self, Closure requestClosure) {
         doRequestAsync(self, new GetWarmersRequest(), requestClosure, self.&getWarmers)
     }
 
@@ -464,8 +886,23 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetSettingsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#getSettingsAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<GetSettingsResponse> getSettings(IndicesAdminClient self, Closure requestClosure) {
+        getSettingsAsync(self, requestClosure)
+    }
+
+    /**
+     * Get index settings.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link GetSettingsRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null}
+     */
+    static ListenableActionFuture<GetSettingsResponse> getSettingsAsync(IndicesAdminClient self,
+                                                                        Closure requestClosure) {
         doRequestAsync(self, new GetSettingsRequest(), requestClosure, self.&getSettings)
     }
 
@@ -476,10 +913,26 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link AnalyzeRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null} except {@code text}
+     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#analyzeAsync}.
      */
+    @Deprecated
     static ListenableActionFuture<AnalyzeResponse> analyze(IndicesAdminClient self,
                                                            String text,
                                                            Closure requestClosure) {
+        analyzeAsync(self, text, requestClosure)
+    }
+
+    /**
+     * Analyze the {@code text} using the provided index.
+     *
+     * @param self The {@code this} reference for the {@link IndicesAdminClient}.
+     * @param requestClosure The map-like closure that configures the {@link AnalyzeRequest}.
+     * @return Never {@code null}.
+     * @throws NullPointerException if any parameter is {@code null} except {@code text}
+     */
+    static ListenableActionFuture<AnalyzeResponse> analyzeAsync(IndicesAdminClient self,
+                                                                String text,
+                                                                Closure requestClosure) {
         // text must currently be supplied to the constructor
         doRequestAsync(self, new AnalyzeRequest(text), requestClosure, self.&analyze)
     }

--- a/src/main/groovy/org/elasticsearch/groovy/client/IndicesAdminClientExtensions.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/client/IndicesAdminClientExtensions.groovy
@@ -99,7 +99,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<RefreshResponse> refresh(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.refreshRequest(), requestClosure, self.&refresh)
+        doRequestAsync(self, Requests.refreshRequest(), requestClosure, self.&refresh)
     }
 
     /**
@@ -111,7 +111,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<IndicesExistsResponse> exists(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.indicesExistsRequest(), requestClosure, self.&exists)
+        doRequestAsync(self, Requests.indicesExistsRequest(), requestClosure, self.&exists)
     }
 
     /**
@@ -124,7 +124,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<TypesExistsResponse> typesExists(IndicesAdminClient self, Closure requestClosure) {
         // indices must be supplied by the closure
-        doRequest(self, new TypesExistsRequest(null), requestClosure, self.&typesExists)
+        doRequestAsync(self, new TypesExistsRequest(null), requestClosure, self.&typesExists)
     }
 
     /**
@@ -136,7 +136,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<IndicesStatsResponse> stats(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, new IndicesStatsRequest(), requestClosure, self.&stats)
+        doRequestAsync(self, new IndicesStatsRequest(), requestClosure, self.&stats)
     }
 
     /**
@@ -148,7 +148,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<RecoveryResponse> recoveries(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, new RecoveryRequest(), requestClosure, self.&recoveries)
+        doRequestAsync(self, new RecoveryRequest(), requestClosure, self.&recoveries)
     }
 
     /**
@@ -160,7 +160,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<IndicesSegmentResponse> segments(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.indicesExistsRequest(), requestClosure, self.&segments)
+        doRequestAsync(self, Requests.indicesExistsRequest(), requestClosure, self.&segments)
     }
 
     /**
@@ -173,7 +173,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<CreateIndexResponse> create(IndicesAdminClient self, Closure requestClosure) {
         // index must be set by the closure
-        doRequest(self, Requests.createIndexRequest(null), requestClosure, self.&create)
+        doRequestAsync(self, Requests.createIndexRequest(null), requestClosure, self.&create)
     }
 
     /**
@@ -188,7 +188,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<DeleteIndexResponse> delete(IndicesAdminClient self, Closure requestClosure) {
         // index must be set by the closure
-        doRequest(self, Requests.deleteIndexRequest(null), requestClosure, self.&delete)
+        doRequestAsync(self, Requests.deleteIndexRequest(null), requestClosure, self.&delete)
     }
 
     /**
@@ -202,7 +202,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<CloseIndexResponse> close(IndicesAdminClient self, Closure requestClosure) {
         // index must be set by the closure
-        doRequest(self, Requests.closeIndexRequest(null), requestClosure, self.&close)
+        doRequestAsync(self, Requests.closeIndexRequest(null), requestClosure, self.&close)
     }
 
     /**
@@ -215,7 +215,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<OpenIndexResponse> open(IndicesAdminClient self, Closure requestClosure) {
         // index must be set by the closure
-        doRequest(self, Requests.openIndexRequest(null), requestClosure, self.&open)
+        doRequestAsync(self, Requests.openIndexRequest(null), requestClosure, self.&open)
     }
 
     /**
@@ -230,7 +230,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<FlushResponse> flush(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.flushRequest(), requestClosure, self.&flush)
+        doRequestAsync(self, Requests.flushRequest(), requestClosure, self.&flush)
     }
 
     /**
@@ -249,7 +249,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<OptimizeResponse> optimize(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.optimizeRequest(), requestClosure, self.&optimize)
+        doRequestAsync(self, Requests.optimizeRequest(), requestClosure, self.&optimize)
     }
 
     /**
@@ -261,7 +261,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<GetMappingsResponse> getMappings(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, new GetMappingsRequest(), requestClosure, self.&getMappings)
+        doRequestAsync(self, new GetMappingsRequest(), requestClosure, self.&getMappings)
     }
 
     /**
@@ -274,7 +274,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<GetFieldMappingsResponse> getFieldMappings(IndicesAdminClient self,
                                                                              Closure requestClosure) {
-        doRequest(self, new GetFieldMappingsRequest(), requestClosure, self.&getFieldMappings)
+        doRequestAsync(self, new GetFieldMappingsRequest(), requestClosure, self.&getFieldMappings)
     }
 
     /**
@@ -286,7 +286,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<PutMappingResponse> putMapping(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.putMappingRequest(), requestClosure, self.&putMapping)
+        doRequestAsync(self, Requests.putMappingRequest(), requestClosure, self.&putMapping)
     }
 
     /**
@@ -299,7 +299,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<DeleteMappingResponse> deleteMapping(IndicesAdminClient self,
                                                                        Closure requestClosure) {
-        doRequest(self, Requests.deleteMappingRequest(), requestClosure, self.&deleteMapping)
+        doRequestAsync(self, Requests.deleteMappingRequest(), requestClosure, self.&deleteMapping)
     }
 
     /**
@@ -311,7 +311,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<IndicesAliasesResponse> aliases(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, Requests.indexAliasesRequest(), requestClosure, self.&aliases)
+        doRequestAsync(self, Requests.indexAliasesRequest(), requestClosure, self.&aliases)
     }
 
     /**
@@ -323,7 +323,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<GetAliasesResponse> getAliases(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, new GetAliasesRequest(), requestClosure, self.&getAliases)
+        doRequestAsync(self, new GetAliasesRequest(), requestClosure, self.&getAliases)
     }
 
     /**
@@ -335,7 +335,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<AliasesExistResponse> aliasesExist(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, new GetAliasesRequest(), requestClosure, self.&aliasesExist)
+        doRequestAsync(self, new GetAliasesRequest(), requestClosure, self.&aliasesExist)
     }
 
     /**
@@ -348,7 +348,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<ClearIndicesCacheResponse> clearCache(IndicesAdminClient self,
                                                                         Closure requestClosure) {
-        doRequest(self, Requests.clearIndicesCacheRequest(), requestClosure, self.&clearCache)
+        doRequestAsync(self, Requests.clearIndicesCacheRequest(), requestClosure, self.&clearCache)
     }
 
     /**
@@ -363,7 +363,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<UpdateSettingsResponse> updateSettings(IndicesAdminClient self,
                                                                          Closure requestClosure) {
-        doRequest(self, new UpdateSettingsRequest(), requestClosure, self.&updateSettings)
+        doRequestAsync(self, new UpdateSettingsRequest(), requestClosure, self.&updateSettings)
     }
 
     /**
@@ -377,7 +377,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
     static ListenableActionFuture<PutIndexTemplateResponse> putTemplate(IndicesAdminClient self,
                                                                         Closure requestClosure) {
         // template name expected be supplied by the closure
-        doRequest(self, new PutIndexTemplateRequest(null), requestClosure, self.&putTemplate)
+        doRequestAsync(self, new PutIndexTemplateRequest(null), requestClosure, self.&putTemplate)
     }
 
     /**
@@ -391,7 +391,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if {@code self} is {@code null}
      */
     static ListenableActionFuture<DeleteIndexTemplateResponse> deleteTemplate(IndicesAdminClient self, String name) {
-        doRequest(self, new DeleteIndexTemplateRequest(name), self.&deleteTemplate)
+        doRequestAsync(self, new DeleteIndexTemplateRequest(name), self.&deleteTemplate)
     }
 
     /**
@@ -404,7 +404,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<GetIndexTemplatesResponse> getTemplates(IndicesAdminClient self,
                                                                           Closure requestClosure) {
-        doRequest(self, new GetIndexTemplatesRequest(), requestClosure, self.&getTemplates)
+        doRequestAsync(self, new GetIndexTemplatesRequest(), requestClosure, self.&getTemplates)
     }
 
     /**
@@ -417,7 +417,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<ValidateQueryResponse> validateQuery(IndicesAdminClient self,
                                                                        Closure requestClosure) {
-        doRequest(self, new ValidateQueryRequest(), requestClosure, self.&validateQuery)
+        doRequestAsync(self, new ValidateQueryRequest(), requestClosure, self.&validateQuery)
     }
 
     /**
@@ -430,7 +430,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      */
     static ListenableActionFuture<PutWarmerResponse> putWarmer(IndicesAdminClient self, Closure requestClosure) {
         // warmer name is expected to be set by the closure
-        doRequest(self, new PutWarmerRequest(null), requestClosure, self.&putWarmer)
+        doRequestAsync(self, new PutWarmerRequest(null), requestClosure, self.&putWarmer)
     }
 
     /**
@@ -442,7 +442,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<DeleteWarmerResponse> deleteWarmer(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, new DeleteWarmerRequest(), requestClosure, self.&deleteWarmer)
+        doRequestAsync(self, new DeleteWarmerRequest(), requestClosure, self.&deleteWarmer)
     }
 
     /**
@@ -454,7 +454,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<GetWarmersResponse> getWarmers(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, new GetWarmersRequest(), requestClosure, self.&getWarmers)
+        doRequestAsync(self, new GetWarmersRequest(), requestClosure, self.&getWarmers)
     }
 
     /**
@@ -466,7 +466,7 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<GetSettingsResponse> getSettings(IndicesAdminClient self, Closure requestClosure) {
-        doRequest(self, new GetSettingsRequest(), requestClosure, self.&getSettings)
+        doRequestAsync(self, new GetSettingsRequest(), requestClosure, self.&getSettings)
     }
 
     /**
@@ -481,6 +481,6 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
                                                            String text,
                                                            Closure requestClosure) {
         // text must currently be supplied to the constructor
-        doRequest(self, new AnalyzeRequest(text), requestClosure, self.&analyze)
+        doRequestAsync(self, new AnalyzeRequest(text), requestClosure, self.&analyze)
     }
 }

--- a/src/test/groovy/org/elasticsearch/groovy/client/AbstractClientTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/client/AbstractClientTests.groovy
@@ -98,7 +98,7 @@ abstract class AbstractClientTests extends AbstractElasticsearchIntegrationTest 
     String indexDoc(String indexName, String typeName, Closure doc) {
         String docId = randomInt()
 
-        IndexResponse indexResponse = client.index {
+        IndexResponse indexResponse = client.indexAsync {
             index indexName
             type typeName
             id docId
@@ -172,7 +172,7 @@ abstract class AbstractClientTests extends AbstractElasticsearchIntegrationTest 
      * @throws IllegalArgumentException if any of the {@code indexConfigs} call invoke invalid methods.
      */
     BulkResponse bulkIndex(String indexName, List<Closure> indexConfigs) {
-        BulkResponse bulkResponse = client.bulk {
+        BulkResponse bulkResponse = client.bulkAsync {
             // note: this adds a List<IndexRequest>
             add indexConfigs.collect {
                 Requests.indexRequest(indexName).with(it)

--- a/src/test/groovy/org/elasticsearch/groovy/client/ClientExtensionsActionTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/client/ClientExtensionsActionTests.groovy
@@ -53,6 +53,8 @@ class ClientExtensionsActionTests extends AbstractClientTests {
      */
     String typeName = 'actions'
 
+    // REPLACE WITH non-Async variants in 2.0
+
     @Test
     void testIndexRequest() {
         String tweetId = randomInt()
@@ -553,6 +555,502 @@ class ClientExtensionsActionTests extends AbstractClientTests {
         assert ! getResponse.exists
     }
 
+    //
+    // START OF requestAsync test variants (combine sections with sync versus async variant side-by-side in 2.0)
+    //
+
+    @Test
+    void testIndexRequestAsync() {
+        String tweetId = randomInt()
+
+        IndexResponse response = client.indexAsync {
+            index indexName
+            type 'tweet'
+            id tweetId
+            source {
+                user = "kimchy"
+                message = "this is a tweet!"
+            }
+        }.actionGet()
+
+        assert response.index == indexName
+        assert response.type == 'tweet'
+        assert response.id == tweetId
+    }
+
+    @Test
+    void testDeleteRequestAsync() {
+        String docId = indexDoc(indexName, typeName) {
+            user = randomAsciiOfLengthBetween(1, 16)
+        }
+
+        // don't need a refresh, since we're not searching for it
+        DeleteResponse response = client.deleteAsync {
+            index indexName
+            type typeName
+            id docId
+        }.actionGet()
+
+        assert response.found
+        assert response.id == docId
+
+        // don't need a refresh, since we're not searching for it
+        GetResponse getResponse = client.getAsync {
+            index indexName
+            type typeName
+            id docId
+        }.actionGet()
+
+        assert ! getResponse.exists
+    }
+
+    @Test
+    void testUpdateRequestAsync() {
+        String userId = randomAsciiOfLengthBetween(1, 16)
+
+        int nestedValue = randomInt()
+
+        String docId = indexDoc(indexName, typeName) {
+            user = userId
+        }
+
+        // update the document by adding a nested object (creatively named "nested")
+        UpdateResponse response = client.updateAsync {
+            index indexName
+            type typeName
+            id docId
+            doc {
+                nested {
+                    value = nestedValue
+                }
+            }
+        }.actionGet()
+
+        assert ! response.created
+        assert response.version == 2
+
+        // don't need a refresh, since we're not searching for it
+        GetResponse getResponse = client.getAsync {
+            index indexName
+            type typeName
+            id docId
+        }.actionGet()
+
+        assert getResponse.exists
+        assert getResponse.version == 2
+        assert getResponse.sourceAsMap["user"] == userId
+        assert getResponse.sourceAsMap.nested.value == nestedValue
+    }
+
+    @Test
+    void testGetRequestAsync() {
+        String userId = randomAsciiOfLengthBetween(1, 16)
+
+        String docId = indexDoc(indexName, typeName) {
+            user = userId
+        }
+
+        // don't need a refresh, since we're not searching for it
+        GetResponse response = client.getAsync {
+            index indexName
+            type typeName
+            id docId
+        }.actionGet()
+
+        assert response.exists
+        assert response.id == docId
+        assert response.sourceAsMap["user"] == userId
+    }
+
+    @Test
+    void testMultiGetRequestAsync() {
+        String userId1 = randomAsciiOfLengthBetween(1, 4)
+        String userId2 = randomAsciiOfLengthBetween(5, 8)
+        String userId3 = randomAsciiOfLengthBetween(9, 12)
+
+        // Three separate index operations
+        BulkResponse bulkResponse = bulkIndex(indexName, [
+            {
+                type typeName
+                source { user = userId1 }
+            },
+            {
+                type typeName
+                source {
+                    user = userId2
+                    field = randomInt()
+                }
+            },
+            {
+                type typeName
+                source { user = userId3 }
+            }
+        ])
+
+        // don't need a refresh, since we're not searching for it
+        MultiGetResponse response = client.multiGetAsync {
+            for (BulkItemResponse bulkItemResponse : bulkResponse.items) {
+                add indexName, typeName, bulkItemResponse.id
+            }
+        }.actionGet()
+
+        assert response.responses.length == 3
+        assert response.responses[0].response.sourceAsMap.user == userId1
+        assert response.responses[1].response.sourceAsMap.user == userId2
+        assert response.responses[2].response.sourceAsMap.user == userId3
+    }
+
+    @Test
+    void testBulkRequestAsync() {
+        List<String> ids = [randomAsciiOfLength(1), randomAsciiOfLength(2), randomAsciiOfLength(3)]
+
+        BulkResponse response = client.bulkAsync {
+            // Note: this uses add(ActionRequest...) [note the comma between each request]
+            add Requests.indexRequest(indexName).with {
+                type typeName
+                id ids[0]
+                source {
+                    user = randomInt()
+                }
+            },
+            Requests.indexRequest(indexName).with {
+                type typeName
+                id ids[1]
+                source {
+                    user = randomInt()
+                }
+            },
+            Requests.indexRequest(indexName).with {
+                type typeName
+                id ids[2]
+                source {
+                    user = randomInt()
+                }
+            }
+        }.actionGet()
+
+        assert ! response.hasFailures()
+        assert response.items.length == 3
+        // ensure each item was indexed as expected
+        response.items.eachWithIndex { BulkItemResponse item, int i ->
+            assert item.index == indexName
+            assert item.type == typeName
+            assert item.id == ids[i]
+        }
+    }
+
+    @Test
+    void testSearchRequestAsync() {
+        // int used for ID to ensure that the search is simple
+        String userId = randomInt()
+
+        String docId = indexDoc(indexName, typeName) {
+            user = userId
+        }
+
+        // refresh the index to guarantee searchability
+        client.admin.indices.refreshAsync { indices indexName }.actionGet()
+
+        SearchResponse response = client.searchAsync {
+            indices indexName
+            types typeName
+            source {
+                query {
+                    match {
+                        user = userId
+                    }
+                }
+            }
+        }.actionGet()
+
+        assert response.hits.totalHits == 1
+        assert response.hits.hits[0].id == docId
+        assert response.hits.hits[0].source.user == userId
+    }
+
+    @Test
+    void testMultiSearchRequestAsync() {
+        List<Integer> values = bulkIndexValues()
+        // the value that all must be greater than or equal to in the first search; less than in the second search
+        int gteValue = values[randomInt(values.size() - 1)]
+
+        // determine how many indexed documents have a value >= gteValue and, separately value < gteValue
+        MultiSearchResponse response = client.multiSearchAsync {
+            add Requests.searchRequest(indexName).types(typeName).source {
+                query {
+                    range {
+                        value {
+                            gte = gteValue
+                        }
+                    }
+                }
+            }
+            add Requests.searchRequest().with {
+                indices indexName
+                types typeName
+                source {
+                    query {
+                        range {
+                            value {
+                                lt = gteValue
+                            }
+                        }
+                    }
+                }
+            }
+        }.actionGet()
+
+        // the counts should match exactly since they're doing the same operation
+        assert response.responses[0].response.hits.totalHits == values.count { it >= gteValue }
+        assert response.responses[1].response.hits.totalHits == values.count { it < gteValue }
+    }
+
+    @Test
+    void testCountRequestAsync() {
+        List<Integer> values = bulkIndexValues()
+        // the value that all must be greater than or equal to
+        int gteValue = values[randomInt(values.size() - 1)]
+
+        // determine how many indexed documents have a value >= gteValue
+        CountResponse response = client.countAsync {
+            indices indexName
+            types typeName
+            source {
+                query {
+                    range {
+                        value {
+                            gte = gteValue
+                        }
+                    }
+                }
+            }
+        }.actionGet()
+
+        // the counts should match exactly since they're doing the same operation
+        assert response.count == values.count { it >= gteValue }
+    }
+
+    @Test
+    void testDeleteByQueryRequestAsync() {
+        List<Integer> values = bulkIndexValues()
+        // the value that all must be greater than or equal to
+        int gteValue = values[randomInt(values.size() - 1)]
+
+        DeleteByQueryResponse response = client.deleteByQueryAsync {
+            indices indexName
+            types typeName
+            source {
+                query {
+                    range {
+                        value {
+                            gte = gteValue
+                        }
+                    }
+                }
+            }
+        }.actionGet()
+
+        // sanity check to ensure that we didn't screw up
+        assert response.indices[indexName].failedShards == 0
+
+        // guarantee that the deletes take effect
+        assert client.admin.indices.refreshAsync { indices indexName }.actionGet().failedShards == 0
+
+        // determine how many indexed documents have a value >= gteValue
+        CountResponse countResponse = client.countAsync {
+            indices indexName
+            types typeName
+            source {
+                query {
+                    match_all { }
+                }
+            }
+        }.actionGet()
+
+        // the counts should match exactly since we have the whole data set and are performing the opposite calculation
+        assert countResponse.count == values.count { it < gteValue }
+    }
+
+    @Test
+    void testSearchScrollRequestAsync() {
+        // index some arbitrary data
+        List<Integer> values =  bulkIndexValues()
+
+        // Open a new scroll ID
+        SearchResponse searchResponse = client.searchAsync {
+            source {
+                query {
+                    match_all { }
+                }
+                // Note: Size is per relevant shard!
+                size 1000
+            }
+            searchType SearchType.SCAN
+            scroll "60s"
+        }.actionGet()
+
+        // sanity check
+        assert searchResponse.hits.totalHits == values.size()
+        assert searchResponse.scrollId != null
+        assert searchResponse.hits.hits.length == 0
+
+        SearchResponse response = client.searchScrollAsync {
+            scrollId searchResponse.scrollId
+            // keep the next window open
+            scroll "60s"
+        }.actionGet()
+
+        // Cleanup any open/locked resources
+        ClearScrollResponse clearResponse = client.clearScrollAsync {
+            // NOTE: The response contains the _next_ scroll ID
+            addScrollId response.scrollId
+        }.actionGet()
+
+        // Ensure that it was successful
+        assert clearResponse.succeeded
+    }
+
+    @Test
+    void testClearScrollRequestAsync() {
+        // index some arbitrary data
+        List<Integer> values =  bulkIndexValues()
+
+        // Open a new scroll ID
+        SearchResponse searchResponse = client.searchAsync {
+            source {
+                query {
+                    match_all { }
+                }
+                // Note: Size is per relevant shard!
+                size 1000
+            }
+            searchType SearchType.SCAN
+            scroll "60s"
+        }.actionGet()
+
+        // sanity check
+        assert searchResponse.hits.totalHits == values.size()
+        assert searchResponse.scrollId != null
+
+        // Cleanup any open/locked resources
+        ClearScrollResponse response = client.clearScrollAsync {
+            addScrollId searchResponse.scrollId
+        }.actionGet()
+
+        // Ensure that it was successful
+        assert response.succeeded
+    }
+
+    @Test
+    void testPutIndexedScriptRequestAsync() {
+        int startCount = randomInt(1024)
+
+        String docId = indexDoc(indexName, typeName) {
+            // actual value is ignored
+            user = randomAsciiOfLengthBetween(1, 16)
+            count = startCount
+        }
+
+        // index the script
+        PutIndexedScriptResponse response = client.putIndexedScriptAsync {
+            id 'testPutIndexedScriptRequestAsync'
+            // NOTE: This will be the Groovy runtime within Elasticsearch and not the Groovy client (this)
+            scriptLang 'groovy'
+            source {
+                // NOTE: The script is [in this case] Groovy, but it must be a string that is interpreted on the server
+                script = "ctx._source.count += count"
+            }
+        }.actionGet()
+
+        assert response.created
+
+        UpdateResponse updateResponse = client.updateAsync {
+            index indexName
+            type typeName
+            id docId
+            source {
+                script_id 'testPutIndexedScriptRequestAsync'
+                lang 'groovy'
+                params {
+                    count = 5
+                }
+            }
+        }.actionGet()
+
+        assert ! updateResponse.created
+        assert updateResponse.id == docId
+        assert updateResponse.version == 2
+
+        GetResponse getResponse = client.getAsync {
+            index indexName
+            type typeName
+            id docId
+        }.actionGet()
+
+        assert getResponse.exists
+        assert getResponse.version == updateResponse.version
+        assert getResponse.source.user != null
+        assert getResponse.source.count == startCount + 5
+    }
+
+    @Test
+    void testGetIndexedScriptRequestAsync() {
+        String groovyScript = "ctx._source.count += count"
+
+        // index the script
+        PutIndexedScriptResponse putResponse = client.putIndexedScriptAsync {
+            id 'testGetIndexedScriptRequestAsync'
+            // NOTE: This will be the Groovy runtime within Elasticsearch and not the Groovy client (this)
+            scriptLang 'groovy'
+            source {
+                // NOTE: The script is [in this case] Groovy, but it must be a string that is interpreted on the server
+                script = groovyScript
+            }
+        }.actionGet()
+
+        assert putResponse.created
+
+        GetIndexedScriptResponse response = client.getIndexedScriptAsync {
+            id 'testGetIndexedScriptRequestAsync'
+            scriptLang 'groovy'
+        }.actionGet()
+
+        assert response.exists
+        assert response.version == putResponse.version
+        assert response.script == groovyScript
+    }
+
+    @Test
+    void testDeleteIndexedScriptRequestAsync() {
+        String groovyScript = "ctx._source.count += count"
+
+        // index the script
+        PutIndexedScriptResponse putResponse = client.putIndexedScriptAsync {
+            id 'testDeleteIndexedScriptRequestAsync'
+            scriptLang 'groovy'
+            source {
+                script = "ctx._source.count += count"
+            }
+        }.actionGet()
+
+        assert putResponse.created
+
+        // perform the delete
+        DeleteIndexedScriptResponse response = client.deleteIndexedScriptAsync {
+            id 'testDeleteIndexedScriptRequestAsync'
+            scriptLang 'groovy'
+        }.actionGet()
+
+        assert response.found
+
+        GetIndexedScriptResponse getResponse = client.getIndexedScriptAsync {
+            id 'testDeleteIndexedScriptRequestAsync'
+            scriptLang 'groovy'
+        }.actionGet()
+
+        assert ! getResponse.exists
+    }
+
     /**
      * Bulk index a random number of documents containing a random integer field named "value" at its root.
      * <p />
@@ -584,7 +1082,7 @@ class ClientExtensionsActionTests extends AbstractClientTests {
         })
 
         // refresh the index to guarantee searchability
-        assert client.admin.indices.refresh { indices indexName }.actionGet().failedShards == 0
+        assert client.admin.indices.refreshAsync{ indices indexName }.actionGet().failedShards == 0
 
         values
     }

--- a/src/test/groovy/org/elasticsearch/groovy/client/ClusterAdminClientExtensionsActionTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/client/ClusterAdminClientExtensionsActionTests.groovy
@@ -57,6 +57,8 @@ class ClusterAdminClientExtensionsActionTests extends AbstractClientTests {
         clusterAdminClient = client.admin.cluster
     }
 
+    // REPLACE WITH non-Async variants in 2.0
+
     @Test
     void testHealthRequest() {
         indexDoc(indexName, typeName) { name = "ignored" }
@@ -193,6 +195,155 @@ class ClusterAdminClientExtensionsActionTests extends AbstractClientTests {
 
         // Ensure that the restored index was expected renamed
         GetResponse getResponse = client.get {
+            index restoredIndexName
+            type typeName
+            id docId
+        }.actionGet()
+
+        assert getResponse.exists
+        assert getResponse.sourceAsMap.value == expectedValue
+    }
+
+    //
+    // START OF requestAsync test variants (combine sections with sync versus async variant side-by-side in 2.0)
+    //
+
+    @Test
+    void testHealthRequestAsync() {
+        indexDoc(indexName, typeName) { name = "ignored" }
+
+        ClusterHealthResponse response = clusterAdminClient.healthAsync {
+            indices indexName
+            waitForStatus ClusterHealthStatus.YELLOW
+        }.actionGet()
+
+        // waited for Yellow, so it had better not be Red
+        assert response.status != ClusterHealthStatus.RED
+    }
+
+    @Test
+    void testPutRepositoryRequestAndGetRepositoryRequestAsync() {
+        String repoName = "test-repo-async"
+        String absolutePath = newTempDir().absolutePath
+
+        // Create the repository
+        PutRepositoryResponse response = clusterAdminClient.putRepositoryAsync {
+            name repoName
+            type "fs"
+            settings {
+                compress = true
+                location = absolutePath
+            }
+        }.actionGet()
+
+        assert response.acknowledged
+
+        // verify that it exists
+        GetRepositoriesResponse getResponse = clusterAdminClient.getRepositoriesAsync {
+            repositories repoName
+        }.actionGet()
+
+        assert getResponse.repositories()[0].name() == repoName
+        assert getResponse.repositories()[0].settings().get("location") == absolutePath
+    }
+
+    @Test
+    void testCreateSnapshotRequestAsync() {
+        String repoName = "test-create-snapshot-repo-async"
+        String snapshotName = "test-create-snapshot-async"
+        String absolutePath = newTempDir().absolutePath
+
+        // Write a document
+        indexDoc(indexName, typeName) { value = "ignored" }
+        // flush the index to disk
+        client.admin.indices.flushAsync { indices indexName }.actionGet()
+
+        // Create the repository
+        PutRepositoryResponse putResponse = clusterAdminClient.putRepositoryAsync {
+            name repoName
+            type "fs"
+            settings {
+                location = absolutePath
+            }
+        }.actionGet()
+
+        // sanity check
+        assert putResponse.acknowledged
+
+        // Create the snapshot
+        CreateSnapshotResponse response = clusterAdminClient.createSnapshotAsync {
+            repository repoName
+            snapshot snapshotName
+            indices indexName
+            waitForCompletion true
+        }.actionGet()
+
+        assert response.snapshotInfo.name() == snapshotName
+        assert response.snapshotInfo.state() == SnapshotState.SUCCESS
+        assert response.snapshotInfo.indices()[0] == indexName
+    }
+
+    @Test
+    void testRestoreSnapshotRequestAsync() {
+        String repoName = "test-restore-snapshot-repo-async"
+        String snapshotName = "test-restore-snapshot-async"
+        String absolutePath = newTempDir().absolutePath
+        String restoredIndexName = indexName + "-restored-async"
+        String expectedValue = "expected"
+
+        // Write a document
+        String docId = indexDoc(indexName, typeName) { value = expectedValue }
+
+        // ensure that the mapping exists before creating the snapshot (required for dynamic mapping!)
+        waitForConcreteMappingsOnAll(indexName, typeName, "value")
+
+        // Create the repository
+        PutRepositoryResponse putResponse = clusterAdminClient.putRepositoryAsync {
+            name repoName
+            type "fs"
+            settings {
+                location = absolutePath
+            }
+        }.actionGet()
+
+        // sanity check
+        assert putResponse.acknowledged
+
+        // Create the snapshot
+        CreateSnapshotResponse createResponse = clusterAdminClient.createSnapshotAsync {
+            repository repoName
+            snapshot snapshotName
+            indices indexName
+            waitForCompletion true
+        }.actionGet()
+
+        // sanity check
+        assert createResponse.snapshotInfo.state() == SnapshotState.SUCCESS
+
+        // Restore the snapshot to another index (indexName -> restoredIndexName)
+        RestoreSnapshotResponse response = clusterAdminClient.restoreSnapshotAsync {
+            repository repoName
+            snapshot snapshotName
+            renamePattern indexName
+            renameReplacement restoredIndexName
+            waitForCompletion true
+        }.actionGet()
+
+        // ensure that we appropriately restored from the snapshot
+        assert response.restoreInfo.name() == snapshotName
+        assert response.restoreInfo.failedShards() == 0
+        assert response.restoreInfo.indices()[0] == restoredIndexName
+
+        ClusterHealthResponse healthResponse = clusterAdminClient.healthAsync {
+            indices restoredIndexName
+            waitForStatus ClusterHealthStatus.YELLOW
+        }.actionGet()
+
+        // sanity check
+        assert ! healthResponse.timedOut
+
+        // Ensure that the restored index was expected renamed
+        GetResponse getResponse = client.getAsync {
             index restoredIndexName
             type typeName
             id docId


### PR DESCRIPTION
This pull request changes _every_ client request that is in the form of:

```
Response response = client.request { /* ... */ }.actionGet()
```

into:

```
Response response = client.requestAsync { /* ... */ }.actionGet()
```

This is intended to make it clear that you are using an asynchronous method in preparation to adding synchronous method variants for the most common usages related.

- This change will go into 1.5+.
- A related, non-backwards compatible change will be created for 2.0+ that will remove the Deprecated asynchronous methods _and_ replace them with synchronous variants (changing their return type from `ListenableActionFuture<Response>` to `Response`!).

This covers the 1.x portion of #21.