### PR TITLE
Adding synchronous request methods in place of deprecated asynchronous variants

### DIFF
--- a/src/main/groovy/org/elasticsearch/groovy/client/ClusterAdminClientExtensions.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/client/ClusterAdminClientExtensions.groovy
@@ -76,11 +76,9 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClusterHealthRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#healthAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<ClusterHealthResponse> health(ClusterAdminClient self, Closure requestClosure) {
-        healthAsync(self, requestClosure)
+    static ClusterHealthResponse health(ClusterAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.clusterHealthRequest(), requestClosure, self.&health)
     }
 
     /**
@@ -102,11 +100,9 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClusterStateRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#stateAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<ClusterStateResponse> state(ClusterAdminClient self, Closure requestClosure) {
-        stateAsync(self, requestClosure)
+    static ClusterStateResponse state(ClusterAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.clusterStateRequest(), requestClosure, self.&state)
     }
 
     /**
@@ -128,12 +124,10 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClusterUpdateSettingsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#updateSettingsAsync}.
      */
-    @Deprecated
     static ListenableActionFuture<ClusterUpdateSettingsResponse> updateSettings(ClusterAdminClient self,
                                                                                 Closure requestClosure) {
-        updateSettingsAsync(self, requestClosure)
+        doRequest(self, Requests.clusterUpdateSettingsRequest(), requestClosure, self.&updateSettings)
     }
 
     /**
@@ -145,7 +139,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<ClusterUpdateSettingsResponse> updateSettingsAsync(ClusterAdminClient self,
-                                                                                Closure requestClosure) {
+                                                                                     Closure requestClosure) {
         doRequestAsync(self, Requests.clusterUpdateSettingsRequest(), requestClosure, self.&updateSettings)
     }
 
@@ -158,11 +152,9 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClusterRerouteRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#rerouteAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<ClusterRerouteResponse> reroute(ClusterAdminClient self, Closure requestClosure) {
-        rerouteAsync(self, requestClosure)
+    static ClusterRerouteResponse reroute(ClusterAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.clusterRerouteRequest(), requestClosure, self.&reroute)
     }
 
     /**
@@ -187,11 +179,9 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClusterStatsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#clusterStatsAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<ClusterStatsResponse> clusterStats(ClusterAdminClient self, Closure requestClosure) {
-        clusterStatsAsync(self, requestClosure)
+    static ClusterStatsResponse clusterStats(ClusterAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.clusterStatsRequest(), requestClosure, self.&clusterStats)
     }
 
     /**
@@ -214,11 +204,9 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link NodesInfoRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#nodeInfoAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<NodesInfoResponse> nodesInfo(ClusterAdminClient self, Closure requestClosure) {
-        nodesInfoAsync(self, requestClosure)
+    static NodesInfoResponse nodesInfo(ClusterAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.nodesInfoRequest(), requestClosure, self.&nodesInfo)
     }
 
     /**
@@ -240,11 +228,9 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link NodesStatsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#nodeStatsAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<NodesStatsResponse> nodesStats(ClusterAdminClient self, Closure requestClosure) {
-        nodesStatsAsync(self, requestClosure)
+    static NodesStatsResponse nodesStats(ClusterAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.nodesStatsRequest(), requestClosure, self.&nodesStats)
     }
 
     /**
@@ -266,12 +252,9 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link NodesHotThreadsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#nodesHotThreadsAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<NodesHotThreadsResponse> nodesHotThreads(ClusterAdminClient self,
-                                                                           Closure requestClosure) {
-        nodesHotThreadsAsync(self, requestClosure)
+    static NodesHotThreadsResponse nodesHotThreads(ClusterAdminClient self, Closure requestClosure) {
+        doRequest(self, new NodesHotThreadsRequest(), requestClosure, self.&nodesHotThreads)
     }
 
     /**
@@ -294,12 +277,9 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link NodesShutdownRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#nodesShutdownAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<NodesShutdownResponse> nodesShutdown(ClusterAdminClient self,
-                                                                       Closure requestClosure) {
-        nodesShutdownAsync(self, requestClosure)
+    static NodesShutdownResponse nodesShutdown(ClusterAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.nodesShutdownRequest(), requestClosure, self.&nodesShutdown)
     }
 
     /**
@@ -322,12 +302,9 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClusterSearchShardsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#searchShardsAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<ClusterSearchShardsResponse> searchShards(ClusterAdminClient self,
-                                                                            Closure requestClosure) {
-        searchShardsAsync(self, requestClosure)
+    static ClusterSearchShardsResponse searchShards(ClusterAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.clusterSearchShardsRequest(), requestClosure, self.&searchShards)
     }
 
     /**
@@ -350,12 +327,10 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link PutRepositoryRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#putSnapshotAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<PutRepositoryResponse> putRepository(ClusterAdminClient self,
-                                                                       Closure requestClosure) {
-        putRepositoryAsync(self, requestClosure)
+    static PutRepositoryResponse putRepository(ClusterAdminClient self, Closure requestClosure) {
+        // closure is expected to set the repo name
+        doRequest(self, Requests.putRepositoryRequest(null), requestClosure, self.&putRepository)
     }
 
     /**
@@ -379,12 +354,10 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link DeleteRepositoryRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#deleteRepositoryAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<DeleteRepositoryResponse> deleteRepository(ClusterAdminClient self,
-                                                                             Closure requestClosure) {
-        deleteRepositoryAsync(self, requestClosure)
+    static DeleteRepositoryResponse deleteRepository(ClusterAdminClient self, Closure requestClosure) {
+        // closure is expected to set the repo name
+        doRequest(self, Requests.deleteRepositoryRequest(null), requestClosure, self.&deleteRepository)
     }
 
     /**
@@ -408,12 +381,9 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetRepositoriesRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#getRepositoriesAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<GetRepositoriesResponse> getRepositories(ClusterAdminClient self,
-                                                                           Closure requestClosure) {
-        getRepositoriesAsync(self, requestClosure)
+    static GetRepositoriesResponse getRepositories(ClusterAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.getRepositoryRequest(), requestClosure, self.&getRepositories)
     }
 
     /**
@@ -436,12 +406,10 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link CreateSnapshotRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#createSnapshotAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<CreateSnapshotResponse> createSnapshot(ClusterAdminClient self,
-                                                                         Closure requestClosure) {
-        createSnapshotAsync(self, requestClosure)
+    static CreateSnapshotResponse createSnapshot(ClusterAdminClient self, Closure requestClosure) {
+        // closure is expected to set the repo and snapshot names
+        doRequest(self, Requests.createSnapshotRequest(null, null), requestClosure, self.&createSnapshot)
     }
 
     /**
@@ -465,12 +433,10 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link SnapshotsStatusRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#snapshotsStatusAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<SnapshotsStatusResponse> snapshotsStatus(ClusterAdminClient self,
-                                                                           Closure requestClosure) {
-        snapshotsStatusAsync(self, requestClosure)
+    static SnapshotsStatusResponse snapshotsStatus(ClusterAdminClient self, Closure requestClosure) {
+        // closure is expected to set the repo name
+        doRequest(self, Requests.snapshotsStatusRequest(null), requestClosure, self.&snapshotsStatus)
     }
 
     /**
@@ -494,11 +460,10 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetSnapshotsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#getSnapshotsAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<GetSnapshotsResponse> getSnapshots(ClusterAdminClient self, Closure requestClosure) {
-        getSnapshotsAsync(self, requestClosure)
+    static GetSnapshotsResponse getSnapshots(ClusterAdminClient self, Closure requestClosure) {
+        // closure is expected to set the repo name
+        doRequest(self, Requests.getSnapshotsRequest(null), requestClosure, self.&getSnapshots)
     }
 
     /**
@@ -522,12 +487,10 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link RestoreSnapshotRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#restoreSnapshotAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<RestoreSnapshotResponse> restoreSnapshot(ClusterAdminClient self,
-                                                                           Closure requestClosure) {
-        restoreSnapshotAsync(self, requestClosure)
+    static RestoreSnapshotResponse restoreSnapshot(ClusterAdminClient self, Closure requestClosure) {
+        // closure is expected to set the repo and snapshot names
+        doRequest(self, Requests.restoreSnapshotRequest(null, null), requestClosure, self.&restoreSnapshot)
     }
 
     /**
@@ -539,7 +502,7 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @throws NullPointerException if any parameter is {@code null}
      */
     static ListenableActionFuture<RestoreSnapshotResponse> restoreSnapshotAsync(ClusterAdminClient self,
-                                                                           Closure requestClosure) {
+                                                                                Closure requestClosure) {
         // closure is expected to set the repo and snapshot names
         doRequestAsync(self, Requests.restoreSnapshotRequest(null, null), requestClosure, self.&restoreSnapshot)
     }
@@ -554,12 +517,10 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link DeleteSnapshotRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#deleteSnapshotAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<DeleteSnapshotResponse> deleteSnapshot(ClusterAdminClient self,
-                                                                         Closure requestClosure) {
-        deleteSnapshotAsync(self, requestClosure)
+    static DeleteSnapshotResponse deleteSnapshot(ClusterAdminClient self, Closure requestClosure) {
+        // closure is expected to set the repo and snapshot names
+        doRequest(self, Requests.deleteSnapshotRequest(null, null), requestClosure, self.&deleteSnapshot)
     }
 
     /**
@@ -588,12 +549,9 @@ class ClusterAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link PendingClusterTasksRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link ClusterAdminClient#pendingClusterTasksAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<PendingClusterTasksResponse> pendingClusterTasks(ClusterAdminClient self,
-                                                                                   Closure requestClosure) {
-        pendingClusterTasksAsync(self, requestClosure)
+    static PendingClusterTasksResponse pendingClusterTasks(ClusterAdminClient self, Closure requestClosure) {
+        doRequest(self, new PendingClusterTasksRequest(), requestClosure, self.&pendingClusterTasks)
     }
 
     /**

--- a/src/main/groovy/org/elasticsearch/groovy/client/IndicesAdminClientExtensions.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/client/IndicesAdminClientExtensions.groovy
@@ -95,11 +95,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link RefreshRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#refreshAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<RefreshResponse> refresh(IndicesAdminClient self, Closure requestClosure) {
-        refreshAsync(self, requestClosure)
+    static RefreshResponse refresh(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.refreshRequest(), requestClosure, self.&refresh)
     }
 
     /**
@@ -121,11 +119,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link IndicesExistsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#existsAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<IndicesExistsResponse> exists(IndicesAdminClient self, Closure requestClosure) {
-        existsAsync(self, requestClosure)
+    static IndicesExistsResponse exists(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.indicesExistsRequest(), requestClosure, self.&exists)
     }
 
     /**
@@ -147,11 +143,10 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link TypesExistsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#typesExistsAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<TypesExistsResponse> typesExists(IndicesAdminClient self, Closure requestClosure) {
-        typesExistsAsync(self, requestClosure)
+    static TypesExistsResponse typesExists(IndicesAdminClient self, Closure requestClosure) {
+        // indices must be supplied by the closure
+        doRequest(self, new TypesExistsRequest(null), requestClosure, self.&typesExists)
     }
 
     /**
@@ -175,11 +170,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link IndicesStatsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#statsAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<IndicesStatsResponse> stats(IndicesAdminClient self, Closure requestClosure) {
-        statsAsync(self, requestClosure)
+    static IndicesStatsResponse stats(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, new IndicesStatsRequest(), requestClosure, self.&stats)
     }
 
     /**
@@ -201,11 +194,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link RecoveryRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#recoveriesAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<RecoveryResponse> recoveries(IndicesAdminClient self, Closure requestClosure) {
-        recoveriesAsync(self, requestClosure)
+    static RecoveryResponse recoveries(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, new RecoveryRequest(), requestClosure, self.&recoveries)
     }
 
     /**
@@ -227,11 +218,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link IndicesSegmentsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#segmentsAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<IndicesSegmentResponse> segments(IndicesAdminClient self, Closure requestClosure) {
-        segmentsAsync(self, requestClosure)
+    static IndicesSegmentResponse segments(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.indicesExistsRequest(), requestClosure, self.&segments)
     }
 
     /**
@@ -254,11 +243,10 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link CreateIndexRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#createAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<CreateIndexResponse> create(IndicesAdminClient self, Closure requestClosure) {
-        createAsync(self, requestClosure)
+    static CreateIndexResponse create(IndicesAdminClient self, Closure requestClosure) {
+        // index must be set by the closure
+        doRequest(self, Requests.createIndexRequest(null), requestClosure, self.&create)
     }
 
     /**
@@ -283,11 +271,10 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link DeleteIndexRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#deleteAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<DeleteIndexResponse> delete(IndicesAdminClient self, Closure requestClosure) {
-        deleteAsync(self, requestClosure)
+    static DeleteIndexResponse delete(IndicesAdminClient self, Closure requestClosure) {
+        // index must be set by the closure
+        doRequest(self, Requests.deleteIndexRequest(null), requestClosure, self.&delete)
     }
 
     /**
@@ -313,11 +300,10 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link CloseIndexRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#closeAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<CloseIndexResponse> close(IndicesAdminClient self, Closure requestClosure) {
-        closeAsync(self, requestClosure)
+    static CloseIndexResponse close(IndicesAdminClient self, Closure requestClosure) {
+        // index must be set by the closure
+        doRequest(self, Requests.closeIndexRequest(null), requestClosure, self.&close)
     }
 
     /**
@@ -341,11 +327,10 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link OpenIndexRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#openAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<OpenIndexResponse> open(IndicesAdminClient self, Closure requestClosure) {
-        openAsync(self, requestClosure)
+    static OpenIndexResponse open(IndicesAdminClient self, Closure requestClosure) {
+        // index must be set by the closure
+        doRequest(self, Requests.openIndexRequest(null), requestClosure, self.&open)
     }
 
     /**
@@ -371,11 +356,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link FlushRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#flushAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<FlushResponse> flush(IndicesAdminClient self, Closure requestClosure) {
-        flushAsync(self, requestClosure)
+    static FlushResponse flush(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.flushRequest(), requestClosure, self.&flush)
     }
 
     /**
@@ -407,11 +390,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link OptimizeRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#optimizeAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<OptimizeResponse> optimize(IndicesAdminClient self, Closure requestClosure) {
-        optimizeAsync(self, requestClosure)
+    static OptimizeResponse optimize(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.optimizeRequest(), requestClosure, self.&optimize)
     }
 
     /**
@@ -440,11 +421,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetMappingsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#getMappingsAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<GetMappingsResponse> getMappings(IndicesAdminClient self, Closure requestClosure) {
-        getMappingsAsync(self, requestClosure)
+    static GetMappingsResponse getMappings(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, new GetMappingsRequest(), requestClosure, self.&getMappings)
     }
 
     /**
@@ -466,12 +445,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetFieldMappingsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#getFieldMappingsAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<GetFieldMappingsResponse> getFieldMappings(IndicesAdminClient self,
-                                                                             Closure requestClosure) {
-        getFieldMappingsAsync(self, requestClosure)
+    static GetFieldMappingsResponse getFieldMappings(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, new GetFieldMappingsRequest(), requestClosure, self.&getFieldMappings)
     }
 
     /**
@@ -494,11 +470,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link PutMappingRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#putMappingAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<PutMappingResponse> putMapping(IndicesAdminClient self, Closure requestClosure) {
-        putMappingAsync(self, requestClosure)
+    static PutMappingResponse putMapping(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.putMappingRequest(), requestClosure, self.&putMapping)
     }
 
     /**
@@ -520,11 +494,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link IndicesAliasesRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#aliasesAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<IndicesAliasesResponse> aliases(IndicesAdminClient self, Closure requestClosure) {
-        aliasesAsync(self, requestClosure)
+    static IndicesAliasesResponse aliases(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.indexAliasesRequest(), requestClosure, self.&aliases)
     }
 
     /**
@@ -547,11 +519,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetAliasesRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#getAliasesAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<GetAliasesResponse> getAliases(IndicesAdminClient self, Closure requestClosure) {
-        getAliasesAsync(self, requestClosure)
+    static GetAliasesResponse getAliases(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, new GetAliasesRequest(), requestClosure, self.&getAliases)
     }
 
     /**
@@ -573,11 +543,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetAliasesRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#aliasesExistAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<AliasesExistResponse> aliasesExist(IndicesAdminClient self, Closure requestClosure) {
-        aliasesExistAsync(self, requestClosure)
+    static AliasesExistResponse aliasesExist(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, new GetAliasesRequest(), requestClosure, self.&aliasesExist)
     }
 
     /**
@@ -600,12 +568,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ClearIndicesCacheRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#clearCacheAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<ClearIndicesCacheResponse> clearCache(IndicesAdminClient self,
-                                                                        Closure requestClosure) {
-        clearCacheAsync(self, requestClosure)
+    static ClearIndicesCacheResponse clearCache(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, Requests.clearIndicesCacheRequest(), requestClosure, self.&clearCache)
     }
 
     /**
@@ -630,12 +595,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link UpdateSettingsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#updateSettingsAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<UpdateSettingsResponse> updateSettings(IndicesAdminClient self,
-                                                                         Closure requestClosure) {
-        updateSettingsAsync(self, requestClosure)
+    static UpdateSettingsResponse updateSettings(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, new UpdateSettingsRequest(), requestClosure, self.&updateSettings)
     }
 
     /**
@@ -660,12 +622,10 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link PutIndexTemplateRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#putTemplateAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<PutIndexTemplateResponse> putTemplate(IndicesAdminClient self,
-                                                                        Closure requestClosure) {
-        putTemplateAsync(self, requestClosure)
+    static PutIndexTemplateResponse putTemplate(IndicesAdminClient self, Closure requestClosure) {
+        // template name expected be supplied by the closure
+        doRequest(self, new PutIndexTemplateRequest(null), requestClosure, self.&putTemplate)
     }
 
     /**
@@ -691,11 +651,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param name The name of the index template to delete.
      * @return Never {@code null}.
      * @throws NullPointerException if {@code self} is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#deleteTemplateAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<DeleteIndexTemplateResponse> deleteTemplate(IndicesAdminClient self, String name) {
-        deleteTemplateAsync(self, name)
+    static DeleteIndexTemplateResponse deleteTemplate(IndicesAdminClient self, String name) {
+        doRequest(self, new DeleteIndexTemplateRequest(name), self.&deleteTemplate)
     }
 
     /**
@@ -720,12 +678,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetIndexTemplatesRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#getTemplatesAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<GetIndexTemplatesResponse> getTemplates(IndicesAdminClient self,
-                                                                          Closure requestClosure) {
-        getTemplatesAsync(self, requestClosure)
+    static GetIndexTemplatesResponse getTemplates(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, new GetIndexTemplatesRequest(), requestClosure, self.&getTemplates)
     }
 
     /**
@@ -748,12 +703,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link ValidateQueryRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#validateQueryAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<ValidateQueryResponse> validateQuery(IndicesAdminClient self,
-                                                                       Closure requestClosure) {
-        validateQueryAsync(self, requestClosure)
+    static ValidateQueryResponse validateQuery(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, new ValidateQueryRequest(), requestClosure, self.&validateQuery)
     }
 
     /**
@@ -776,11 +728,10 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link PutWarmerRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#putWarmerAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<PutWarmerResponse> putWarmer(IndicesAdminClient self, Closure requestClosure) {
-        putWarmerAsync(self, requestClosure)
+    static PutWarmerResponse putWarmer(IndicesAdminClient self, Closure requestClosure) {
+        // warmer name is expected to be set by the closure
+        doRequest(self, new PutWarmerRequest(null), requestClosure, self.&putWarmer)
     }
 
     /**
@@ -803,11 +754,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link DeleteWarmerRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#deleteWarmerAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<DeleteWarmerResponse> deleteWarmer(IndicesAdminClient self, Closure requestClosure) {
-        deleteWarmerAsync(self, requestClosure)
+    static DeleteWarmerResponse deleteWarmer(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, new DeleteWarmerRequest(), requestClosure, self.&deleteWarmer)
     }
 
     /**
@@ -830,11 +779,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetWarmersRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#getWarmersAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<GetWarmersResponse> getWarmers(IndicesAdminClient self, Closure requestClosure) {
-        getWarmersAsync(self, requestClosure)
+    static GetWarmersResponse getWarmers(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, new GetWarmersRequest(), requestClosure, self.&getWarmers)
     }
 
     /**
@@ -856,11 +803,9 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link GetSettingsRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#getSettingsAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<GetSettingsResponse> getSettings(IndicesAdminClient self, Closure requestClosure) {
-        getSettingsAsync(self, requestClosure)
+    static GetSettingsResponse getSettings(IndicesAdminClient self, Closure requestClosure) {
+        doRequest(self, new GetSettingsRequest(), requestClosure, self.&getSettings)
     }
 
     /**
@@ -883,13 +828,10 @@ class IndicesAdminClientExtensions extends AbstractClientExtensions {
      * @param requestClosure The map-like closure that configures the {@link AnalyzeRequest}.
      * @return Never {@code null}.
      * @throws NullPointerException if any parameter is {@code null} except {@code text}
-     * @deprecated As of 1.5, replaced by {@link IndicesAdminClientExtensions#analyzeAsync}.
      */
-    @Deprecated
-    static ListenableActionFuture<AnalyzeResponse> analyze(IndicesAdminClient self,
-                                                           String text,
-                                                           Closure requestClosure) {
-        analyzeAsync(self, text, requestClosure)
+    static AnalyzeResponse analyze(IndicesAdminClient self, String text, Closure requestClosure) {
+        // text must currently be supplied to the constructor
+        doRequest(self, new AnalyzeRequest(text), requestClosure, self.&analyze)
     }
 
     /**

--- a/src/test/groovy/org/elasticsearch/groovy/client/AbstractClientTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/client/AbstractClientTests.groovy
@@ -98,12 +98,12 @@ abstract class AbstractClientTests extends AbstractElasticsearchIntegrationTest 
     String indexDoc(String indexName, String typeName, Closure doc) {
         String docId = randomInt()
 
-        IndexResponse indexResponse = client.indexAsync {
+        IndexResponse indexResponse = client.index {
             index indexName
             type typeName
             id docId
             source doc
-        }.actionGet()
+        }
 
         // sanity check
         assert indexResponse.id == docId
@@ -172,12 +172,12 @@ abstract class AbstractClientTests extends AbstractElasticsearchIntegrationTest 
      * @throws IllegalArgumentException if any of the {@code indexConfigs} call invoke invalid methods.
      */
     BulkResponse bulkIndex(String indexName, List<Closure> indexConfigs) {
-        BulkResponse bulkResponse = client.bulkAsync {
+        BulkResponse bulkResponse = client.bulk {
             // note: this adds a List<IndexRequest>
             add indexConfigs.collect {
                 Requests.indexRequest(indexName).with(it)
             }
-        }.actionGet()
+        }
 
         // sanity check
         assert ! bulkResponse.hasFailures()

--- a/src/test/groovy/org/elasticsearch/groovy/client/IndicesAdminClientExtensionsActionTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/client/IndicesAdminClientExtensionsActionTests.groovy
@@ -52,8 +52,6 @@ class IndicesAdminClientExtensionsActionTests extends AbstractClientTests {
         indicesAdminClient = client.admin.indices
     }
 
-    // REPLACE WITH non-Async variants in 2.0
-
     @Test
     void testRefreshRequest() {
         String docId = indexDoc(indexName, typeName) {
@@ -63,7 +61,7 @@ class IndicesAdminClientExtensionsActionTests extends AbstractClientTests {
         // refresh the index to guarantee searchability
         RefreshResponse response = indicesAdminClient.refresh {
             indices indexName
-        }.actionGet()
+        }
 
         assert response.failedShards == 0
 
@@ -78,15 +76,11 @@ class IndicesAdminClientExtensionsActionTests extends AbstractClientTests {
                     }
                 }
             }
-        }.actionGet()
+        }
 
         assert searchResponse.hits.totalHits == 1
         assert searchResponse.hits.hits[0].id == docId
     }
-
-    //
-    // START OF requestAsync test variants (combine sections with sync versus async variant side-by-side in 2.0)
-    //
 
     @Test
     void testRefreshRequestAsync() {
@@ -130,13 +124,13 @@ class IndicesAdminClientExtensionsActionTests extends AbstractClientTests {
         // refresh the index to guarantee searchability
         RefreshResponse refreshResponse = indicesAdminClient.refresh {
             indices indexName
-        }.actionGet()
+        }
 
         assert refreshResponse.failedShards == 0
 
         GetMappingsResponse response = indicesAdminClient.getMappings {
             indices indexName
-        }.actionGet()
+        }
 
         // extra the mapping for the current index/type
         MappingMetaData mappingMetaData = response.mappings.get(indexName).get(typeName)


### PR DESCRIPTION
This pull request changes _every_ client to remove the Deprecated, asynchronous methods that did not end with `Async`.

In their place, a related, synchronous replacement has been added that drops the `ListenableActionFuture<Response>` responses in favor of an immediate `Response`.

This is related to #22, and it is the second half that replaces the deprecated methods with their synchronous variants.

Closes #21 