### PR TITLE
Directly support inner field names (e.g., "name.first")

### DIFF
--- a/src/main/groovy/org/elasticsearch/groovy/ClosureToMapConverter.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/ClosureToMapConverter.groovy
@@ -73,7 +73,7 @@ package org.elasticsearch.groovy
  * }
  * </pre>
  * Mixing the two styles is allowed, but consistency is naturally very important for code readability.
- * <p />
+ * <p>
  * Instances should never be reused. Instances of this class are not thread safe, but separate instances do not share
  * any state and therefore multiple instances can run in parallel.
  * @see ClosureExtensions#asMap(Closure)
@@ -86,40 +86,37 @@ class ClosureToMapConverter {
      * @return Never {@code null}. Can be {@link Map#isEmpty() empty}.
      */
     static Map<String, Object> mapClosure(Closure closure) {
-        new ClosureToMapConverter(closure).convert()
+        mapClosureWithOwner(closure, closure.owner)
     }
 
     /**
-     * Convert the passed in {@code value} into an object that is not a {@link Closure}, and convert any
-     * {@link Collection}s into {@link List}s.
-     * <p />
-     * This will recursively call itself as necessary.
+     * Convert the {@code closure} into a {@link Map}.
+     * <p>
+     * The {@code owner} comes up when users specify variables within the {@link Closure}.
      *
-     * @param value The incoming parameter to convert if necessary ({@link Closure}s and {@link Collection}s)
-     * @return {@code value} as-is unless it is a {@link Closure} or {@link Collection}. Otherwise the unraveled
-     *         value of those objects.
+     * @param closure The closure to convert.
+     * @Param owner The owner of the {@code closure}.
+     * @return Never {@code null}. Can be {@link Map#isEmpty() empty}.
      */
-    private static Object convertValue(Object value) {
-        Object ret = value
-
-        // enable nested objects
-        if (value instanceof Closure) {
-            // avoid overwriting this instance's map
-            ret = mapClosure(value)
-        }
-        // unravel collections into a List
-        else if (value instanceof Collection) {
-            // use _this_ method by passing its method address to be invoked
-            ret = ((Collection)value).collect(ClosureToMapConverter.&convertValue)
-        }
-        // unravel arrays into a List (note: this hits native arrays like int[])
-        else if (value instanceof Object[] || (value != null && value.getClass().isArray())) {
-            ret = (value as List).collect(ClosureToMapConverter.&convertValue)
-        }
-
-        ret
+    private static Map<String, Object> mapClosureWithOwner(Closure closure, Object owner) {
+        new ClosureToMapConverter(closure, owner).convert()
     }
 
+    /**
+     * The "buildName" is used to maintain state for names like "field.innerField.nested", which
+     * is actually 3 separate fields without recognizing it.
+     * <pre>
+     * Map&lt;String, Object&gt; map = mapClosure {
+     *   field.innerField.nested = value
+     * }
+     * </pre>
+     * This allows us to parse the field name as literally "field.innerField.nested" by tracking requests
+     * for the field "field", followed by "innerField" and finally attempting to set "nested".
+     * <p>
+     * This format should <em>only</em> be used when for things like changing settings or searching (e.g.,
+     * a match request against an inner field or a nested query).
+     */
+    private String buildName = null
     /**
      * The unraveled {@link Closure} after calling {@link #convert()}.
      */
@@ -128,6 +125,13 @@ class ClosureToMapConverter {
      * The closure that is unraveled into the {@link #map}.
      */
     final Closure closure
+    /**
+     * The owner of the root {@link #closure}.
+     * <p>
+     * Inner {@link Closure}s handle their owner differently than the root one, so it's important to track the root's
+     * owner.
+     */
+    final Object rootOwner
 
     /**
      * Construct a new {@link ClosureToMapConverter} that delegates the {@code closure} to call the constructed
@@ -138,8 +142,21 @@ class ClosureToMapConverter {
      * @throws NullPointerException if {@code closure} is {@code null}
      */
     private ClosureToMapConverter(Closure closure) {
+        this(closure, closure.owner)
+    }
+
+    /**
+     * Construct a new {@link ClosureToMapConverter} that delegates the {@code closure} to call the constructed
+     * instance ({@code this}) when it is invoked. These calls are used to unravel the {@code closure} into the
+     * {@link #map}.
+     *
+     * @param closure The {@link Closure} to convert into a {@link Map}.
+     * @throws NullPointerException if {@code closure} is {@code null}
+     */
+    private ClosureToMapConverter(Closure closure, Object owner) {
         // required
         this.closure = (Closure)closure.clone()
+        this.rootOwner = owner
 
         // When looking up properties and invoking methods, it first looks at the delegate (THIS) for the value. If
         //  the delegate (THIS) does not have it, then it will check the owner for the value (effectively the closure).
@@ -150,7 +167,7 @@ class ClosureToMapConverter {
 
     /**
      * Trigger the conversion of the {@link #closure} to the {@link #map}.
-     * <p />
+     * <p>
      * This method should only be invoked once.
      *
      * @return Never {@code null}. {@link Map#isEmpty() Empty} if the {@code closure} does not assign any properties.
@@ -206,10 +223,67 @@ class ClosureToMapConverter {
 
     /**
      * Get the value defined in the {@link #map} with the {@code propertyName}.
+     * <p>
+     * This method has a side-effect <em>if</em> you are requesting a {@code propertyName} that is unrecognized to both
+     * {@code this} (its internal {@link #map}) or the {@link #rootOwner}. In that case, the this method will remember
+     * the {@code propertyName} for future use with {@link #setProperty} or {@link #invokeMethod}.
+     * <p>
+     * The reason that it keeps track of this the {@code propertyName} is because this method is only called when a
+     * value is sought. In general, that only occurs on the <em>right hand side</em> (e.g., x = y, where y is the right
+     * hand side). However, if the value is unrecognized, then it's either an error <em>or</em>, more likely, it's being
+     * used in the form of "x.y.z = a" rather than "x { y { z = a } }". Doing this should is considered an error.
+     * <pre>
+     * Map&lt;String, Object&gt; map = mapClosure {
+     *   x.y.z = 123
+     *   a = x.y.z     // BAD!!
+     * }
+     * </pre>
+     * If you really need similar functionality, then define a temporary variable <em>outside</em> of the
+     * {@code Closure} and use it.
+     * <pre>
+     * int value = 123
+     *
+     * Map&lt;String, Object&gt; map = mapClosure {
+     *   x.y.z = value
+     *   a = value     // GOOD!!
+     * }
+     * </pre>
+     * <p>
+     * Perhaps unexpectedly, this will <em>never</em> return property values unless given the full name. When Groovy
+     * is unraveling the shorthand version, this method is called twice in the above example. Once with "x", again with
+     * "y", and finally the setter is called against "y" for "z". By tracking "x" and "y", we can appropriately create
+     * the "x.y.z" key that is intended. Because we are building it, we don't want to return any value that we happen
+     * across "along the way" because each key in this format is effectively not associated with others.
      */
     @Override
     Object getProperty(String propertyName) {
-        map[propertyName]
+        Object returned = this
+
+        // if we know about it, then return the value
+        if (map.containsKey(propertyName)) {
+            returned = map[propertyName]
+        }
+        // NOTE: The following blocks are here to handle the less common "key1.key2" on the left-hand side
+        //       This is meant to be less common
+        // if we don't know about it, then start building the actual key name
+        //  (key is in form of "key1.key2.key3" and this will be "key1"
+        else if (buildName == null) {
+            // If the OWNER of the closure has the value, then we want to use that value because it will
+            // NOTE: This "owner" is only the same as "closure.owner" for the root closure.
+            if (rootOwner.hasProperty(propertyName)) {
+                // the owner has it, so just return that value (this _should_ be on the right hand side used as a value)
+                returned = rootOwner.getProperty(propertyName)
+            }
+            else {
+                buildName = propertyName
+            }
+        }
+        // continuation from above where it's now "key2"; this method would never get "key3" unless it was on the
+        else {
+            buildName += '.' + propertyName
+        }
+
+        returned
     }
 
     /**
@@ -221,6 +295,55 @@ class ClosureToMapConverter {
      */
     @Override
     void setProperty(String propertyName, Object newValue) {
-        map[propertyName] = convertValue(newValue)
+        String fullName = propertyName
+
+        // If we are maintaining state trying to load the name
+        if (buildName != null) {
+            fullName = buildName + "." + propertyName
+            // We just now saw "key3", so we can throw away the name now
+            buildName = null
+        }
+
+        map[fullName] = convertValue(newValue)
+    }
+
+    /**
+     * Convert the passed in {@code value} into an object that is not a {@link Closure}, and convert any
+     * {@link Collection}s into {@link List}s.
+     * <p>
+     * This will recursively call itself as necessary.
+     *
+     * @param value The incoming parameter to convert if necessary ({@link Closure}s and {@link Collection}s)
+     * @return {@code value} as-is unless it is a {@link Closure} or {@link Collection}. Otherwise the unraveled
+     *         value of those objects.
+     * @throws IllegalArgumentException if you attempt to reuse a shorthand property on the right and side (e.g.,
+     *                                  "x.y.z = a; b = x.y.z;" where "x.y.z" is the shorthand property)
+     */
+    private Object convertValue(Object value) {
+        Object ret = value
+
+        // avoid handling
+        if (value instanceof ClosureToMapConverter) {
+            throw new IllegalArgumentException(
+                    "value is a ClosureToMapConverter. This means that you are trying to reuse a shorthand " +
+                    "property! (For example, { x.y.z = 123; a = x.y.z }. 'x.y.z' cannot be referenced on the right " +
+                    "hand side!)")
+        }
+        // enable nested objects
+        else if (value instanceof Closure) {
+            // avoid overwriting this instance's map; maintain the owner!
+            ret = mapClosureWithOwner(value, rootOwner)
+        }
+        // unravel collections into a List
+        else if (value instanceof Collection) {
+            // use _this_ method by passing its method address to be invoked
+            ret = ((Collection)value).collect(this.&convertValue)
+        }
+        // unravel arrays into a List (note: this hits native arrays like int[])
+        else if (value instanceof Object[] || (value != null && value.getClass().isArray())) {
+            ret = (value as List).collect(this.&convertValue)
+        }
+
+        ret
     }
 }

--- a/src/main/groovy/org/elasticsearch/groovy/ClosureToMapConverter.groovy
+++ b/src/main/groovy/org/elasticsearch/groovy/ClosureToMapConverter.groovy
@@ -316,18 +316,19 @@ class ClosureToMapConverter {
      * @param value The incoming parameter to convert if necessary ({@link Closure}s and {@link Collection}s)
      * @return {@code value} as-is unless it is a {@link Closure} or {@link Collection}. Otherwise the unraveled
      *         value of those objects.
-     * @throws IllegalArgumentException if you attempt to reuse a shorthand property on the right and side (e.g.,
+     * @throws IllegalArgumentException if you attempt to reuse a shorthand property on the right hand side (e.g.,
      *                                  "x.y.z = a; b = x.y.z;" where "x.y.z" is the shorthand property)
      */
     private Object convertValue(Object value) {
         Object ret = value
 
-        // avoid handling
+        // avoid handling shorthand assignments (technically we could check for this, then build the name here, but
+        //  this is a very bad code smell; just use a temporary variable!)
         if (value instanceof ClosureToMapConverter) {
             throw new IllegalArgumentException(
                     "value is a ClosureToMapConverter. This means that you are trying to reuse a shorthand " +
                     "property! (For example, { x.y.z = 123; a = x.y.z }. 'x.y.z' cannot be referenced on the right " +
-                    "hand side!)")
+                    "hand side! Use a temporary variable from outside the closure instead.)")
         }
         // enable nested objects
         else if (value instanceof Closure) {

--- a/src/test/groovy/org/elasticsearch/groovy/ClosureToMapConverterTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/ClosureToMapConverterTests.groovy
@@ -69,7 +69,8 @@ class ClosureToMapConverterTests extends AbstractElasticsearchTestCase {
         mapClosure {
             // Note: You define 'x' to be an int
             x = randomInt()
-            // Now we try to define 'x.y.z', but
+            // Now we try to define 'x.y.z', but 'x' already exists so it gets returned; then it tries to find 'y' as
+            //  a property of 'x', which won't exist
             x.y.z = randomInt()
         }
     }

--- a/src/test/groovy/org/elasticsearch/groovy/ClosureToMapConverterTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/ClosureToMapConverterTests.groovy
@@ -26,9 +26,75 @@ import static org.elasticsearch.groovy.ClosureToMapConverter.mapClosure
  * Tests {@link ClosureToMapConverter}.
  */
 class ClosureToMapConverterTests extends AbstractElasticsearchTestCase {
+    /**
+     * A random {@code long} value.
+     * <p>
+     * This is specifically called out as a local field to ensure that the {@link Closure} properly uses the field via
+     * delegation.
+     */
+    private long value = randomLong()
+
+    /**
+     * "Short Hand" means that we are using using the full property name rather than nesting closures. It's the
+     * difference between
+     * <pre>
+     * {
+     *   x.y.z = 123
+     * }
+     * </pre>
+     * and
+     * <pre>
+     * {
+     *   x {
+     *     y {
+     *       z = 123
+     *     }
+     *   }
+     * }
+     * </pre>
+     * Using the short hand form is <em>not</em> allowed on the right hand side (it adds a lot of unnecessary
+     * complexity).
+     */
+    @Test(expected = IllegalArgumentException)
+    void testShortHandOnRightHandSide_Fails() {
+        mapClosure {
+            x.y.z = randomInt()
+            // NOT ALLOWED:
+            c = x.y.z     // <--- This is not allowed!
+        }
+    }
+
+    @Test(expected = MissingPropertyException)
+    void testShortHand_FailsWithBadOrder() {
+        mapClosure {
+            // Note: You define 'x' to be an int
+            x = randomInt()
+            // Now we try to define 'x.y.z', but
+            x.y.z = randomInt()
+        }
+    }
+
+    @Test
+    void testShortHandValid() {
+        Map<String, Object> values = [key: randomInt()]
+
+        // NOTE: The keys are intentionally ordered. The testShortHand_FailsWithBadOrder test will try the other order
+        Map<String, Object> map = mapClosure {
+            a.b.c = value
+            a = value     // Proper way to reuse the value from a shorthand property
+
+            b.c.d = values.key
+            b = values.key
+        }
+
+        assert map['a.b.c'] == value
+        assert map.a == value
+        assert map['b.c.d'] == values.key
+        assert map.b == values.key
+    }
+
     @Test
     void testFlatMapConversion() {
-        long value = randomLong()
         String string = randomAsciiOfLengthBetween(1, 16)
         Date now = new Date()
         boolean bool = randomBoolean()
@@ -50,8 +116,39 @@ class ClosureToMapConverterTests extends AbstractElasticsearchTestCase {
     }
 
     @Test
+    void testFlatNestedConversion() {
+        String string = randomAsciiOfLengthBetween(1, 16)
+        Date now = new Date()
+        boolean bool = randomBoolean()
+        Map<String, Object> checkMap = [key1: randomInt(), key2: [inner: randomInt()]]
+
+        // This is necessary to handle fields with "." in the name
+        Map<String, Object> map = mapClosure {
+            date = now
+            // Ensure nested field names work
+            object1.id = value
+            // Ensure nested-nested
+            object2.object3.name = string
+            // Ensure nested-nested-nested...
+            object4.object5.object6.valid = bool
+            // Ensure that right-hand side is parsed properly
+            object7.key1 = checkMap.key1
+            object8.key2 = checkMap.key2.inner
+        }
+
+        assert map.date == now
+        // NOTE: You _must_ access the keys as strings because it does _not_ translate
+        // otherwise
+        assert map['object1.id'] == value
+        assert map['object2.object3.name'] == string
+        assert map['object4.object5.object6.valid'] == bool
+        assert map['object7.key1'] == checkMap.key1
+        assert map['object8.key2'] == checkMap.key2.inner
+
+    }
+
+    @Test
     void testReusedVariableMapConversion() {
-        long value = randomLong()
         String string = randomAsciiOfLengthBetween(1, 16)
         Date now = new Date()
         boolean bool = randomBoolean()
@@ -85,7 +182,6 @@ class ClosureToMapConverterTests extends AbstractElasticsearchTestCase {
 
     @Test
     void testListMapConversion() {
-        long value = randomLong()
         List values = [randomAsciiOfLengthBetween(1, 8), randomLong(), randomBoolean()]
 
         Map<String, Object> map = mapClosure {
@@ -99,7 +195,6 @@ class ClosureToMapConverterTests extends AbstractElasticsearchTestCase {
 
     @Test
     void testNestedPropertyMapConversion() {
-        long value = randomLong()
         String firstName = randomAsciiOfLengthBetween(1, 8)
         String lastName = randomAsciiOfLengthBetween(1, 8)
         Date now = new Date()
@@ -128,7 +223,6 @@ class ClosureToMapConverterTests extends AbstractElasticsearchTestCase {
 
     @Test
     void testNestedMethodMapConversion() {
-        long value = randomLong()
         String firstName = randomAsciiOfLengthBetween(1, 8)
         String lastName = randomAsciiOfLengthBetween(1, 8)
         Date now = new Date()
@@ -157,7 +251,6 @@ class ClosureToMapConverterTests extends AbstractElasticsearchTestCase {
 
     @Test
     void testComplexMapConversion() {
-        long value = randomLong()
         String firstName = randomAsciiOfLengthBetween(1, 8)
         String lastName = randomAsciiOfLengthBetween(1, 8)
         Date start = new Date(randomLong())

--- a/src/test/groovy/org/elasticsearch/groovy/common/xcontent/XContentBuilderExtensionsTests.groovy
+++ b/src/test/groovy/org/elasticsearch/groovy/common/xcontent/XContentBuilderExtensionsTests.groovy
@@ -159,6 +159,15 @@ class XContentBuilderExtensionsTests extends AbstractElasticsearchTestCase {
     }
 
     @Test
+    void testDotObjects() {
+        assert '{"categories":["a","b","c"],"rootprop":"something","test.subprop":10}' == {
+            categories = ['a', 'b', 'c']
+            rootprop = 'something'
+            test.subprop = 10
+        }.asJsonString()
+    }
+
+    @Test
     void testNestedObjects() {
         assert '{"categories":["a","b","c"],"rootprop":"something","test":{"subprop":10}}' == {
             categories = ['a', 'b', 'c']


### PR DESCRIPTION
Adding support and tests to allow using left hand side (LHS) fields that contain periods. For example, if you defined the document:

``` json
{
  "name": {
    "first" : "Chris",
    "last" : "Earle"
  }
}
```

You could easily convert this into a Groovy document with the current support:

``` groovy
Map<String, Object> map = {
  name {
    first = "Chris"
    last = "Earle"
  }
}.asMap()
```

This works as expected. However, when you go to query it using the JSON:

``` json
{
  "query" : {
    "match" : {
      "name.first" : "Chris"
    }
  }
}
```

This does not really work using the Groovy DSL. With this bugfix, it does work now, as one would expect:

``` groovy
{
  query {
    match {
      name.first = "Chris"
    }
  }
}
```

**Note**: This pull request has two limitations that are both expected and largely unavoidable.
1. You cannot define a property in this way, and then use it later in the `Closure`.
   
   ``` groovy
   {
     field.value1 = 123
     value2 = field.value1 // THIS WILL BREAK (IllegalArgumentException)
   }
   ```
   
   You may continue to reuse single-named properties on the right hand side (RHS), but not multi-named properties. This could technically be avoided, but it's such an undesirable use that I chose to mark it as a failure.
2. You cannot define a subset of the name, then try to define the long version of it. The reverse order _will_ work.
   
   ``` groovy
   {
     a = 123
     a.b.c = 456 // THIS WILL BREAK (MissingPropertyException)
   }
   ```
   
   As noted, the reverse order _will_ work. There are not many realistic situations that this should occur though.
   
   ``` groovy
   {
     a.b.c = 456
     a = 123 // This will work
   }
   ```

Prior to this pull request, it would throw a `NullPointerException` when trying to do this, but now the only two failure conditions are defined above (`IllegalArgumentException` and `MissingPropertyException`).

---

This change will go into the 1.5 branch, 1.x branch (soon to be 1.6), and master branch (the eventual 2.0).

Closes #25
